### PR TITLE
Configured XML documentation output

### DIFF
--- a/src/MMALSharp.Common/MMALSharp.Common.csproj
+++ b/src/MMALSharp.Common/MMALSharp.Common.csproj
@@ -1,25 +1,31 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">  
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\MMALSharp.Common.props" />
   <PropertyGroup>
     <AssemblyTitle>MMALSharp.Common</AssemblyTitle>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>    
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>MMALSharp.Common</AssemblyName>
     <PackageId>MMALSharp.Common</PackageId>
     <RootNamespace>MMALSharp</RootNamespace>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-  </PropertyGroup>  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">   
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+    <DocumentationFile>bin\Release\net452\MMALSharp.Common.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\MMALSharp.Common.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.0-rc03" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/src/MMALSharp.FFmpeg/MMALSharp.FFmpeg.csproj
+++ b/src/MMALSharp.FFmpeg/MMALSharp.FFmpeg.csproj
@@ -1,26 +1,32 @@
-﻿<Project Sdk="Microsoft.NET.Sdk"> 
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\MMALSharp.FFmpeg.props" />
   <PropertyGroup>
     <AssemblyTitle>MMALSharp.FFmpeg</AssemblyTitle>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>    
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>MMALSharp.FFmpeg</AssemblyName>
     <PackageId>MMALSharp.FFmpeg</PackageId>
     <RootNamespace>MMALSharp</RootNamespace>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-  </PropertyGroup>  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">   
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+    <DocumentationFile>bin\Release\net452\MMALSharp.FFmpeg.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\MMALSharp.FFmpeg.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">    
-	<PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />    
-  </ItemGroup> 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+  </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MMALSharp.Common\MMALSharp.Common.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/src/MMALSharp/MMALSharp.csproj
+++ b/src/MMALSharp/MMALSharp.csproj
@@ -10,6 +10,12 @@
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+    <DocumentationFile>bin\Release\net452\MMALSharp.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\MMALSharp.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
 	<PackageReference Include="Nito.AsyncEx" Version="3.0.1" />

--- a/tests/MMALSharp.Tests/MMALSharp.Tests.csproj
+++ b/tests/MMALSharp.Tests/MMALSharp.Tests.csproj
@@ -26,5 +26,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MMALSharp.Common\MMALSharp.Common.csproj" />
     <ProjectReference Include="..\..\src\MMALSharp\MMALSharp.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>  
 </Project>


### PR DESCRIPTION
I configured the output of XML documentation files. The compiler will now create an XML file in the output directory which resolves #35 .

The `<Service Include="" />` tag in ` tests/MMALSharp.Tests/MMALSharp.Tests.csproj` was automatically made by Visual Studio in order to optimize startup performance with XUnit ([see stackoverflow](https://stackoverflow.com/questions/18614342/what-is-service-include-in-a-csproj-file-for)).