### PR TITLE
Added documentation and improved error suppression

### DIFF
--- a/src/MMALSharp.Common/Handlers/StreamCaptureHandler.cs
+++ b/src/MMALSharp.Common/Handlers/StreamCaptureHandler.cs
@@ -39,6 +39,11 @@ namespace MMALSharp.Handlers
         /// </summary>
         public string Extension { get; protected set; }
 
+        /// <summary>
+        /// Creates a new instance of the StreamCaptureHandler class with the specified directory and filename extension.
+        /// </summary>
+        /// <param name="directory">The directory to save captured data.</param>
+        /// <param name="extension">The filename extension for saving files.</param>
         protected StreamCaptureHandler(string directory, string extension)
         {            
             this.Directory = directory.TrimEnd('/');
@@ -121,6 +126,10 @@ namespace MMALSharp.Handlers
             throw new NotSupportedException("Cannot get filename from non FileStream object");
         }
 
+        /// <summary>
+        /// Gets the filepath that a FileStream points to
+        /// </summary>
+        /// <returns></returns>
         public string GetFilepath()
         {
             if (this.CurrentStream.GetType() == typeof(FileStream))
@@ -131,6 +140,9 @@ namespace MMALSharp.Handlers
             throw new NotSupportedException("Cannot get path from non FileStream object");
         }
 
+        /// <summary>
+        /// Releases the underlying stream.
+        /// </summary>
         public void Dispose()
         {
             CurrentStream?.Dispose();

--- a/src/MMALSharp.Common/Utility/CancellationTokenExtensions.cs
+++ b/src/MMALSharp.Common/Utility/CancellationTokenExtensions.cs
@@ -7,8 +7,16 @@ using System.Threading.Tasks;
 
 namespace MMALSharp.Utility
 {
+    /// <summary>
+    /// This class provides extensions for <see cref="CancellationToken"/>s.
+    /// </summary>
     public static class CancellationTokenExtensions
     {
+        /// <summary>
+        /// Returns a <see cref="Task"/> whose state will be set to <see cref="TaskStatus.Canceled"/> when this <see cref="CancellationToken"/> is canceled.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         public static Task AsTask(this CancellationToken cancellationToken)
         {
             var tcs = new TaskCompletionSource<object>();

--- a/src/MMALSharp/Components/EncoderComponents/MMALEncoderBase.cs
+++ b/src/MMALSharp/Components/EncoderComponents/MMALEncoderBase.cs
@@ -100,7 +100,7 @@ namespace MMALSharp.Components
                     enableTextBackground = 1;
                 }
 
-                textSize = System.Convert.ToByte(MMALCameraConfig.Annotate.TextSize);
+                textSize = Convert.ToByte(MMALCameraConfig.Annotate.TextSize);
 
                 if (MMALCameraConfig.Annotate.TextColour != -1)
                 {

--- a/src/MMALSharp/Components/EncoderComponents/MMALImageEncoder.cs
+++ b/src/MMALSharp/Components/EncoderComponents/MMALImageEncoder.cs
@@ -19,6 +19,9 @@ namespace MMALSharp.Components
     /// </summary>
     public unsafe class MMALImageEncoder : MMALEncoderBase
     {
+        /// <summary>
+        /// Represents the maximum length of a formatted EXIF tag. This includes the tag's key, an equals sign, the tag's value and a null char.
+        /// </summary>
         public const int MaxExifPayloadLength = 128;
 
         private int _width;

--- a/src/MMALSharp/Components/MMALResizerComponent.cs
+++ b/src/MMALSharp/Components/MMALResizerComponent.cs
@@ -9,7 +9,7 @@ using static MMALSharp.Native.MMALParameters;
 namespace MMALSharp.Components
 {
     /// <summary>
-    /// Represents the resizer component. This component has the ability to change the encoding type & pixel format, as well
+    /// Represents the resizer component. This component has the ability to change the encoding type &amp; pixel format, as well
     /// as the width/height of resulting frames.
     /// </summary>
     public sealed class MMALResizerComponent : MMALDownstreamHandlerComponent

--- a/src/MMALSharp/MMALCamera.cs
+++ b/src/MMALSharp/MMALCamera.cs
@@ -31,6 +31,9 @@ namespace MMALSharp
 
         private static readonly Lazy<MMALCamera> lazy = new Lazy<MMALCamera>(() => new MMALCamera());
 
+        /// <summary>
+        /// Gets the singleton instance of the MMAL Camera.
+        /// </summary>
         public static MMALCamera Instance => lazy.Value;
 
         private MMALCamera()

--- a/src/MMALSharp/MMALObject.cs
+++ b/src/MMALSharp/MMALObject.cs
@@ -20,7 +20,7 @@ namespace MMALSharp
         private WeakReference<MMALObject> reference;
 
         /// <summary>
-        /// Initializes a new instance of the MMALObject class and adds this instance to the Objects list.
+        /// Creates a new instance of the MMALObject class and adds this instance to the Objects list.
         /// </summary>
         public MMALObject()
         {

--- a/src/MMALSharp/MMALObject.cs
+++ b/src/MMALSharp/MMALObject.cs
@@ -8,17 +8,29 @@ using System.Collections.Generic;
 
 namespace MMALSharp
 {
+    /// <summary>
+    /// This class is the base class for all MMAL components.
+    /// </summary>
     public abstract class MMALObject : IDisposable
     {
-        public static List<WeakReference<MMALObject>> Objects = new List<WeakReference<MMALObject>>();
+        /// <summary>
+        /// Gets a list of all MMALObjects.
+        /// </summary>
+        public static readonly List<WeakReference<MMALObject>> Objects = new List<WeakReference<MMALObject>>();
         private WeakReference<MMALObject> reference;
 
+        /// <summary>
+        /// Initializes a new instance of the MMALObject class and adds this instance to the Objects list.
+        /// </summary>
         public MMALObject()
         {
             reference = new WeakReference<MMALObject>(this);
             Objects.Add(reference);
         }
-                        
+
+        /// <summary>
+        /// Removes this instance from the Objects list.
+        /// </summary>
         public virtual void Dispose()
         {            
             Objects.Remove(reference);

--- a/src/MMALSharp/Native/BcmHost.cs
+++ b/src/MMALSharp/Native/BcmHost.cs
@@ -12,9 +12,13 @@ using System.Threading.Tasks;
 
 namespace MMALSharp.Native
 {
+    /// <summary>
+    /// Provides interop methods for libbcm_host, the Broadcom hardware interface library.
+    /// </summary>
     public static class BcmHost
     {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable IDE1006 // Naming Styles
 
         [DllImport("libbcm_host.so", EntryPoint = "bcm_host_init", CallingConvention = CallingConvention.Cdecl)]
         public static extern void bcm_host_init();

--- a/src/MMALSharp/Native/MMALBuffer.cs
+++ b/src/MMALSharp/Native/MMALBuffer.cs
@@ -8,7 +8,8 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
     public enum MMALBufferProperties
     {
         MMAL_BUFFER_HEADER_FLAG_EOS = 1 << 0,
@@ -38,6 +39,7 @@ namespace MMALSharp.Native
         // Pointer to void * Pointer to MMAL_BUFFER_HEADER_T -> Returns MMAL_BOOL_T
         public unsafe delegate int MMAL_BH_PRE_RELEASE_CB_T(IntPtr ptr, MMAL_BUFFER_HEADER_T* ptr2);
 
+#pragma warning disable IDE1006 // Naming Styles
         [DllImport("libmmal.so", EntryPoint = "mmal_buffer_header_acquire", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern void mmal_buffer_header_acquire(MMAL_BUFFER_HEADER_T* header);
 
@@ -61,6 +63,7 @@ namespace MMALSharp.Native
 
         [DllImport("libmmal.so", EntryPoint = "mmal_buffer_header_mem_unlock", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern void mmal_buffer_header_mem_unlock(MMAL_BUFFER_HEADER_T* header);
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/MMALSharp/Native/MMALClock.cs
+++ b/src/MMALSharp/Native/MMALClock.cs
@@ -7,7 +7,8 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
     public static class MMALClock
     {
         public static int MMAL_CLOCK_EVENT_MAGIC = MMALUtil.MMAL_FOURCC("CKLM");
@@ -165,5 +166,4 @@ namespace MMALSharp.Native
             this.padding1 = padding1;
         }
     }
-
 }

--- a/src/MMALSharp/Native/MMALCommon.cs
+++ b/src/MMALSharp/Native/MMALCommon.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     [StructLayout(LayoutKind.Sequential)]
     public struct MMAL_CORE_STATISTICS_T

--- a/src/MMALSharp/Native/MMALComponent.cs
+++ b/src/MMALSharp/Native/MMALComponent.cs
@@ -8,11 +8,13 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALComponent
     {
         //name: char* * comp: MMAL_COMPONENT_T**    
+
+#pragma warning disable IDE1006 // Naming Styles
         [DllImport("libmmal.so", EntryPoint = "mmal_component_create", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMALUtil.MMAL_STATUS_T mmal_component_create(string name, IntPtr* comp);
 
@@ -36,6 +38,7 @@ namespace MMALSharp.Native
 
         [DllImport("libmmal.so", EntryPoint = "mmal_wrapper_destroy", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMALUtil.MMAL_STATUS_T mmal_wrapper_destroy(IntPtr* wrapper);
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/MMALSharp/Native/MMALConnection.cs
+++ b/src/MMALSharp/Native/MMALConnection.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALConnection
     {
@@ -25,6 +25,7 @@ namespace MMALSharp.Native
         //typedef - Pointer to MMAL_CONNECTION_T -> Returns MMAL_BOOL_T
         public unsafe delegate int MMAL_CONNECTION_CALLBACK_T(MMAL_CONNECTION_T* conn);
 
+#pragma warning disable IDE1006 // Naming Styles
         [DllImport("libmmal.so", EntryPoint = "mmal_connection_create", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMALUtil.MMAL_STATUS_T mmal_connection_create(IntPtr* connection, MMAL_PORT_T* output, MMAL_PORT_T* input, uint flags);
 
@@ -45,7 +46,7 @@ namespace MMALSharp.Native
 
         [DllImport("libmmal.so", EntryPoint = "mmal_connection_event_format_changed", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMALUtil.MMAL_STATUS_T mmal_connection_event_format_changed(MMAL_CONNECTION_T* connection, MMAL_BUFFER_HEADER_T* buffer);
-
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -60,7 +61,8 @@ namespace MMALSharp.Native
         private long timeSetup, timeEnable, timeDisable;
 
         public IntPtr UserData => userData;
-        public IntPtr Callback {
+        public IntPtr Callback
+        {
             get
             {
                 return this.callback;

--- a/src/MMALSharp/Native/MMALEncodings.cs
+++ b/src/MMALSharp/Native/MMALEncodings.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALEncodingHelpers
     {

--- a/src/MMALSharp/Native/MMALEvents.cs
+++ b/src/MMALSharp/Native/MMALEvents.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALEvents
     {
@@ -21,8 +21,10 @@ namespace MMALSharp.Native
         public static int MMAL_EVENT_FORMAT_CHANGED = MMALUtil.MMAL_FOURCC("EFCH");
         public static int MMAL_EVENT_PARAMETER_CHANGED = MMALUtil.MMAL_FOURCC("EPCH");
 
+#pragma warning disable IDE1006 // Naming Styles
         [DllImport("libmmal.so", EntryPoint = "mmal_event_format_changed_get", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMAL_EVENT_FORMAT_CHANGED_T* mmal_event_format_changed_get(MMAL_BUFFER_HEADER_T* buffer);
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -81,7 +83,4 @@ namespace MMALSharp.Native
             this.hdr = hdr;
         }
     }
-
-
-
 }

--- a/src/MMALSharp/Native/MMALFormat.cs
+++ b/src/MMALSharp/Native/MMALFormat.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALFormat
     {
@@ -34,6 +34,7 @@ namespace MMALSharp.Native
 
         public static int MMAL_ES_FORMAT_COMPARE_FLAG_ES_OTHER = 0x10000000;
 
+#pragma warning disable IDE1006 // Naming Styles
         [DllImport("libmmal.so", EntryPoint = "mmal_format_alloc", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMAL_ES_FORMAT_T* mmal_format_alloc();
 
@@ -51,6 +52,7 @@ namespace MMALSharp.Native
 
         [DllImport("libmmal.so", EntryPoint = "mmal_format_compare", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern uint mmal_format_compare(MMAL_ES_FORMAT_T* ptr, MMAL_ES_FORMAT_T* ptr2);
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -152,8 +154,4 @@ namespace MMALSharp.Native
             this.extraData = extraData;
         }
     }
-
-
-
-
 }

--- a/src/MMALSharp/Native/MMALParameters.cs
+++ b/src/MMALSharp/Native/MMALParameters.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     // mmal_parameters_common.h
 

--- a/src/MMALSharp/Native/MMALPool.cs
+++ b/src/MMALSharp/Native/MMALPool.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALPool
     {
@@ -17,6 +17,7 @@ namespace MMALSharp.Native
         //typedef - Pointer to MMAL_POOL_T struct * Pointer to MMAL_BUFFER_HEADER_T struct * Pointer to void -> Returns MMAL_BOOL_T struct
         public unsafe delegate int MMAL_POOL_BH_CB_T(MMAL_POOL_T* pool, MMAL_BUFFER_HEADER_T* buffer);
 
+#pragma warning disable IDE1006 // Naming Styles
         //MMAL_POOL_T*
         [DllImport("libmmal.so", EntryPoint = "mmal_pool_create", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr mmal_pool_create(uint bufferNum, uint bufferSize);
@@ -40,7 +41,7 @@ namespace MMALSharp.Native
 
         [DllImport("libmmal.so", EntryPoint = "mmal_pool_pre_release_callback_set", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern void mmal_pool_pre_release_callback_set(MMAL_POOL_T* pool, [MarshalAs(UnmanagedType.FunctionPtr)] MMAL_POOL_BH_CB_T cb, IntPtr userdata);
-
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -61,7 +62,4 @@ namespace MMALSharp.Native
             this.header = header;
         }
     }
-
-
-
 }

--- a/src/MMALSharp/Native/MMALPort.cs
+++ b/src/MMALSharp/Native/MMALPort.cs
@@ -8,7 +8,8 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
     public static class MMALPort
     {
         public enum MMAL_PORT_TYPE_T
@@ -26,6 +27,7 @@ namespace MMALSharp.Native
         public const int MMAL_PORT_CAPABILITY_ALLOCATION = 0x02;
         public const int MMAL_PORT_CAPABILITY_SUPPORTS_EVENT_FORMAT_CHANGE = 0x04;
 
+#pragma warning disable IDE1006 // Naming Styles
         //MMAL_PORT_T* port    
         [DllImport("libmmal.so", EntryPoint = "mmal_port_format_commit", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMALUtil.MMAL_STATUS_T mmal_port_format_commit(MMAL_PORT_T* port);
@@ -83,7 +85,7 @@ namespace MMALSharp.Native
         //MMAL_PORT_T* port * MMAL_BUFFER_HEADER_T** buffer
         [DllImport("libmmal.so", EntryPoint = "mmal_port_event_get", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMALUtil.MMAL_STATUS_T mmal_port_event_get(MMAL_PORT_T* port, IntPtr* buffer);
-
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/MMALSharp/Native/MMALQueue.cs
+++ b/src/MMALSharp/Native/MMALQueue.cs
@@ -7,10 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALQueue
     {
+#pragma warning disable IDE1006 // Naming Styles
         //MMAL_QUEUE_T*
         [DllImport("libmmal.so", EntryPoint = "mmal_queue_create", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMAL_QUEUE_T* mmal_queue_create();
@@ -34,6 +35,7 @@ namespace MMALSharp.Native
 
         [DllImport("libmmal.so", EntryPoint = "mmal_queue_destroy", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern void mmal_queue_destroy(MMAL_QUEUE_T* ptr);
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -54,7 +56,4 @@ namespace MMALSharp.Native
             this.last = last;
         }
     }
-
-
-
 }

--- a/src/MMALSharp/Native/MMALUtil.cs
+++ b/src/MMALSharp/Native/MMALUtil.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace MMALSharp.Native
 {
-#pragma warning disable 1591
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     public static class MMALUtil
     {
@@ -51,7 +51,8 @@ namespace MMALSharp.Native
             MMAL_EFAULT,
             MMAL_STATUS_MAX = 0x7FFFFFFF
         }
-               
+
+#pragma warning disable IDE1006 // Naming Styles
         [DllImport("libmmal.so", EntryPoint = "mmal_port_parameter_set_boolean", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern MMAL_STATUS_T mmal_port_parameter_set_boolean(MMAL_PORT_T* port, uint id, int value);
 
@@ -147,7 +148,7 @@ namespace MMALSharp.Native
         
         [DllImport("libmmal.so", EntryPoint = "mmal_4cc_to_string", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern string mmal_4cc_to_string([MarshalAs(UnmanagedType.LPTStr)] string buffer, ushort len, uint fourcc);
-
+#pragma warning restore IDE1006 // Naming Styles
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/MMALSharp/Ports/MMALPortBase.cs
+++ b/src/MMALSharp/Ports/MMALPortBase.cs
@@ -189,6 +189,12 @@ namespace MMALSharp
         /// </summary>
         public Action<MMALBufferImpl, MMALPortBase> ManagedOutputCallback { get; set; }
         
+        /// <summary>
+        /// Initialized a new instance of the MMALPortBase class.
+        /// </summary>
+        /// <param name="ptr">Native pointer that represents this port.</param>
+        /// <param name="comp">Reference to the component this port is associated with.</param>
+        /// <param name="type">The port type.</param>
         protected MMALPortBase(MMAL_PORT_T* ptr, MMALComponentBase comp, PortType type)
         {
             this.Ptr = ptr;
@@ -219,6 +225,13 @@ namespace MMALSharp
             return destinationComponent.Inputs[inputPort];
         }
 
+        /// <summary>
+        /// Connects two components together by their input and output ports
+        /// </summary>
+        /// <param name="destinationComponent">The component we want to connect to</param>
+        /// <param name="inputPort">The input port of the component we want to connect to</param>
+        /// <param name="callback">Callback that will be executed after connecting</param>
+        /// <returns>The input port of the component we're connecting to - allows chain calling of this method</returns>
         public MMALPortBase ConnectTo(MMALDownstreamComponent destinationComponent, int inputPort, Func<MMALPortBase> callback)
         {
             this.ConnectTo(destinationComponent, inputPort);


### PR DESCRIPTION
I have added documentation to a few places where I understand what the methods do.

In native areas I have added comments to the `#pragma warning disable` statements describing which error was disabled. Additionally I have suppressed `IDE1006` stating that methods must be named with first letter uppercase.