### PR TITLE
Minor improvement and more documentation

### DIFF
--- a/src/MMALSharp/Components/MMALCameraComponent.cs
+++ b/src/MMALSharp/Components/MMALCameraComponent.cs
@@ -10,15 +10,47 @@ using MMALSharp.Native;
 
 namespace MMALSharp.Components
 {
+    /// <summary>
+    /// Defines a set of sensor modes that allow to configure how the raw image data is sent to the GPU before further processing. See wiki on GitHub for more information.
+    /// </summary>
+    /// <remarks>
+    /// https://github.com/techyian/MMALSharp/wiki/OmniVision-OV5647-Camera-Module
+    /// https://github.com/techyian/MMALSharp/wiki/Sony-IMX219-Camera-Module
+    /// https://www.raspberrypi.org/forums/viewtopic.php?t=85714
+    /// </remarks>
     public enum MMALSensorMode
     {
+        /// <summary>
+        /// Automatic mode (default).
+        /// </summary>
         Mode0,
+        /// <summary>
+        /// 1080p cropped mode.
+        /// </summary>
         Mode1,
+        /// <summary>
+        /// 4:3 ratio.
+        /// </summary>
         Mode2,
+        /// <summary>
+        /// 4:3 ratio (low FPS with OV5647).
+        /// </summary>
         Mode3,
+        /// <summary>
+        /// 2x2 binned 4:3.
+        /// </summary>
         Mode4,
+        /// <summary>
+        /// 2x2 binned 16:9.
+        /// </summary>
         Mode5,
+        /// <summary>
+        /// High FPS. Ratio and resolution depend on camera module.
+        /// </summary>
         Mode6,
+        /// <summary>
+        /// VGA high FPS.
+        /// </summary>
         Mode7
     }
     
@@ -27,8 +59,17 @@ namespace MMALSharp.Components
     /// </summary>
     public sealed class MMALCameraComponent : MMALComponentBase
     {
+        /// <summary>
+        /// The output port number of the camera's preview port.
+        /// </summary>
         public const int MMALCameraPreviewPort = 0;
+        /// <summary>
+        /// The output port number of the camera's video port.
+        /// </summary>
         public const int MMALCameraVideoPort = 1;
+        /// <summary>
+        /// The output port number of the camera's still port.
+        /// </summary>
         public const int MMALCameraStillPort = 2;
 
         /// <summary>
@@ -100,6 +141,9 @@ namespace MMALSharp.Components
             }
         }
 
+        /// <summary>
+        /// Disposes of the current component, and frees any native resources still in use by it.
+        /// </summary>
         public override void Dispose()
         {
             this.CameraInfo?.DestroyComponent();

--- a/src/MMALSharp/MMALCamera.cs
+++ b/src/MMALSharp/MMALCamera.cs
@@ -325,12 +325,12 @@ namespace MMALSharp
 
             if (cancellationToken == CancellationToken.None)
             {
-                await Task.WhenAll(tasks.ToArray());
+                await Task.WhenAll(tasks);
             }
             else
             {
                 tasks.Add(cancellationToken.AsTask());
-                await Task.WhenAny(tasks.ToArray());
+                await Task.WhenAny(tasks);
             }
             
             this.StopCapture(cameraPort);
@@ -402,6 +402,13 @@ namespace MMALSharp
             return this;
         }
 
+        /// <summary>
+        /// Creates an overlay renderer that is able to render an overlay from a static image source.
+        /// </summary>
+        /// <param name="parent">The parent renderer which is being used to overlay onto the display.</param>
+        /// <param name="config">The configuration for rendering a static preview overlay.</param>
+        /// <param name="source">A reference to the current stream being used in the overlay.</param>
+        /// <returns>The created <see cref="MMALOverlayRenderer"/> object.</returns>
         public MMALOverlayRenderer AddOverlay(MMALVideoRenderer parent, PreviewOverlayConfiguration config, byte[] source)
         {
             var overlay = new MMALOverlayRenderer(parent, config, source);

--- a/src/MMALSharp/MMALCamera.cs
+++ b/src/MMALSharp/MMALCamera.cs
@@ -166,8 +166,6 @@ namespace MMALSharp
                     this.Camera.DisableConnections();
 
                     this.Camera.CleanPortPools();
-
-                    this.Camera.StillPort.SetRawCapture(false);
                 }
                 finally
                 {

--- a/src/MMALSharp/MMALCameraConfig.cs
+++ b/src/MMALSharp/MMALCameraConfig.cs
@@ -11,8 +11,14 @@ using MMALSharp.Native;
 
 namespace MMALSharp
 {
+    /// <summary>
+    /// Provides a rich set of camera/sensor related configuration. Call <see cref="MMALCamera.ConfigureCameraSettings"/> to apply changes.
+    /// </summary>
     public static class MMALCameraConfig
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable verbose debug output for many operations.
+        /// </summary>
         public static bool Debug { get; set; }
 
         /// <summary>
@@ -95,9 +101,8 @@ namespace MMALSharp
 
         /// <summary>
         /// Changing the shutter speed alters how long the sensor is exposed to light (in microseconds).
-        /// 
-        /// There's currently an upper limit of approximately 6000000us (6000ms, 6s), past which operation is undefined. 8MP Sony sensor supports 8s max shutter speed.
-        /// 
+        /// <para />
+        /// There's currently an upper limit of approximately 6.000.000µs (6.000ms, 6s), past which operation is undefined. 8MP Sony sensor supports 8s max shutter speed.
         /// </summary>
         public static int ShutterSpeed { get; set; }
 
@@ -277,6 +282,9 @@ namespace MMALSharp
         Minute
     }
 
+    /// <summary>
+    /// Exposes properties for width and height. This class is used to specify a resolution for camera and ports.
+    /// </summary>
     public class Resolution : IComparable<Resolution>
     {
         /// <summary>
@@ -289,6 +297,11 @@ namespace MMALSharp
         /// </summary>
         public int Height { get; set; }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="Resolution"/> class with the specified width and height.
+        /// </summary>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
         public Resolution(int width, int height)
         {
             this.Width = width;

--- a/src/MMALSharp/Native/MMALEncodings.cs
+++ b/src/MMALSharp/Native/MMALEncodings.cs
@@ -211,6 +211,10 @@ namespace MMALSharp.Native
         public static MMALEncoding BAYER_SBGGR16 = new MMALEncoding("BYR2", EncodingType.PixelFormat);
         public static MMALEncoding BAYER_SBGGR10DPCM8 = new MMALEncoding("bBA8", EncodingType.PixelFormat);
         public static MMALEncoding YUVUV128 = new MMALEncoding("SAND", EncodingType.PixelFormat);
+        /// <summary>
+        /// An opaque buffer is a Broadcom specific format that references a GPU internal bitmap. It is typed as <see cref="EncodingType.Internal"/>.
+        /// </summary>
+        /// <remarks>https://www.raspberrypi.org/forums/viewtopic.php?t=53698</remarks>
         public static MMALEncoding OPAQUE = new MMALEncoding("OPQV", EncodingType.Internal);
         public static MMALEncoding EGL_IMAGE = new MMALEncoding("EGLI", EncodingType.PixelFormat);
         public static MMALEncoding PCM_UNSIGNED_BE = new MMALEncoding("PCMU", EncodingType.PixelFormat);

--- a/src/MMALSharp/Ports/MMALPortExtensions.cs
+++ b/src/MMALSharp/Ports/MMALPortExtensions.cs
@@ -12,6 +12,9 @@ using static MMALSharp.Native.MMALParametersCamera;
 
 namespace MMALSharp
 {
+    /// <summary>
+    /// Provides extension methods to obtain and change the configuration of a port.
+    /// </summary>
     public static class MMALPortExtensions
     {
         /// <summary>
@@ -68,6 +71,11 @@ namespace MMALSharp
             }
         }
         
+        /// <summary>
+        /// Gets a value indicating whether to include raw Bayer image data on this port.
+        /// </summary>
+        /// <param name="port"></param>
+        /// <returns></returns>
         public static bool GetRawCapture(this MMALPortImpl port)
         {
             return port.GetParameter(MMAL_PARAMETER_ENABLE_RAW_CAPTURE);
@@ -156,6 +164,11 @@ namespace MMALSharp
             }
         }
 
+        /// <summary>
+        /// Enables or Disables inclusion of raw Bayer image data on this port.
+        /// </summary>
+        /// <param name="port"></param>
+        /// <param name="enable"></param>
         internal static void SetImageCapture(this MMALPortImpl port, bool enable)
         {
             port.SetParameter(MMAL_PARAMETER_CAPTURE, enable);


### PR DESCRIPTION
Hi Ian,

I have removed the second redundant call `Camera.StillPort.SetRawCapture(false)` in `TakeRawPicture` like discussed in #40 .
At many points I added documentation #37 especially for the camera and preview renderer.
The few changes of the code made names more intuitive and should prevent the user from changing objects that should stay immutable.

Daniel