### PR TITLE
Work on many issues

### DIFF
--- a/src/MMALSharp.Common/GenericExtensions.cs
+++ b/src/MMALSharp.Common/GenericExtensions.cs
@@ -7,8 +7,19 @@ using System;
 
 namespace MMALSharp
 {
+    /// <summary>
+    /// Provides extension methods for mathematical operations.
+    /// </summary>
     public static class GenericExtensions
     {
+        /// <summary>
+        /// Returns a representation of this object that is in the specified range. Too large values will be dreceased to max; too small values will be increased to min.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="val"></param>
+        /// <param name="min">The mininum inclusive value.</param>
+        /// <param name="max">The maximum inclusive value.</param>
+        /// <returns></returns>
         public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>
         {
             if (val.CompareTo(min) < 0)
@@ -24,14 +35,24 @@ namespace MMALSharp
             return val;
         }
 
+        /// <summary>
+        /// Converts a <see cref="byte"/> value to a <see cref="float"/> value from 0.0 to 1.0.
+        /// </summary>
+        /// <param name="val"></param>
+        /// <returns></returns>
         public static float ToFloat(this byte val)
         {
-            return val >= 255 ? 1f : val / 255f;
+            return val >= 255 ? 1.0f : val / 255.0f;
         }
 
+        /// <summary>
+        /// Converts a <see cref="float"/> value (0.0 to 1.0) to a <see cref="byte"/> value from 0 to 255.
+        /// </summary>
+        /// <param name="val"></param>
+        /// <returns></returns>
         public static byte ToByte(this float val)
         {
-            return (byte)(val >= 1.0 ? 255 : val * 256);
+            return (byte)(val >= 1.0f ? 255 : val * 255.0f);
         }
     }
 }

--- a/src/MMALSharp.Common/GenericExtensions.cs
+++ b/src/MMALSharp.Common/GenericExtensions.cs
@@ -42,17 +42,18 @@ namespace MMALSharp
         /// <returns></returns>
         public static float ToFloat(this byte val)
         {
-            return val >= 255 ? 1.0f : val / 255.0f;
+            return val / 255.0f;
         }
 
         /// <summary>
         /// Converts a <see cref="float"/> value (0.0 to 1.0) to a <see cref="byte"/> value from 0 to 255.
         /// </summary>
         /// <param name="val"></param>
+        /// <remarks>https://stackoverflow.com/questions/1914115/converting-color-value-from-float-0-1-to-byte-0-255</remarks>
         /// <returns></returns>
         public static byte ToByte(this float val)
         {
-            return (byte)(val >= 1.0f ? 255 : val * 255.0f);
+            return (byte)(val * 255.999f);
         }
     }
 }

--- a/src/MMALSharp.Common/Utility/Color.cs
+++ b/src/MMALSharp.Common/Utility/Color.cs
@@ -410,9 +410,9 @@ namespace MMALSharp.Utility
         /// Returns a new <see cref="Color"/> structure based from CIEXYZ floating point values. Assumes D65 illuminant.
         /// See: https://en.wikipedia.org/wiki/SRGB#The_forward_transformation_(CIE_XYZ_to_sRGB) 
         /// </summary>
-        /// <param name="x">The chrominance X value (0 <= x <= 0.9505).</param>
-        /// <param name="y">The luminance Y value (0 <= y <= 1.0000).</param>
-        /// <param name="z">The chrominance Z value (0 <= z <= 1.0890).</param>
+        /// <param name="x">The chrominance X value (0 &lt;= x &lt;= 0.9505).</param>
+        /// <param name="y">The luminance Y value (0 &lt;= y &lt;= 1.0000).</param>
+        /// <param name="z">The chrominance Z value (0 &lt;= z &lt;= 1.0890).</param>
         /// <returns>A <see cref="Color"/> structure representing the CIEXYZ parameter values.</returns>
         public static Color FromCieXYZ(float x, float y, float z)
         {

--- a/src/MMALSharp/Components/MMALResizerComponent.cs
+++ b/src/MMALSharp/Components/MMALResizerComponent.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using MMALSharp.Handlers;
+using System;
 using static MMALSharp.Native.MMALParameters;
 
 namespace MMALSharp.Components
@@ -14,15 +15,48 @@ namespace MMALSharp.Components
     /// </summary>
     public sealed class MMALResizerComponent : MMALDownstreamHandlerComponent
     {
-        public override int Width { get; set; }
+        private int _width, _height; // Setting both values to 0 results in an EINVAL. Setting both values to 1 crashes the GPU.
 
-        public override int Height { get; set; }
-
+        /// <summary>
+        /// Creates a new instance of the <see cref="MMALResizerComponent"/> class that can be used to change the size
+        /// and the pixel format of resulting frames. 
+        /// </summary>
+        /// <param name="width">The width of the output frames. Value from 2 to 32767.</param>
+        /// <param name="height">The height of the output frames. Value from 2 to 32767.</param>
+        /// <param name="handler"></param>
         public MMALResizerComponent(int width, int height, ICaptureHandler handler)
             : base(MMAL_COMPONENT_DEFAULT_RESIZER, handler)
         {
             this.Width = width;
             this.Height = height;
+        }
+
+        /// <summary>
+        /// Gets or sets the width of resulting frames. Value from 2 to 32767.
+        /// </summary>
+        public override int Width
+        {
+            get => _width;
+            set
+            {
+                if (value < 2 || value > 32767)
+                    throw new ArgumentOutOfRangeException(nameof(Width), value, "Width must be greater than 1 and smaller than 32768");
+                _width = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the height of resulting frames. Value from 2 to 32767.
+        /// </summary>
+        public override int Height
+        {
+            get => _height;
+            set
+            {
+                if (value < 2 || value > 32767)
+                    throw new ArgumentOutOfRangeException(nameof(Height), value, "Height must be greater than 1 and smaller than 32768");
+                _height = value;
+            }
         }
 
         /// <summary>

--- a/src/MMALSharp/Components/MMALResizerComponent.cs
+++ b/src/MMALSharp/Components/MMALResizerComponent.cs
@@ -16,14 +16,16 @@ namespace MMALSharp.Components
     public sealed class MMALResizerComponent : MMALDownstreamHandlerComponent
     {
         private int _width, _height; // Setting both values to 0 results in an EINVAL. Setting both values to 1 crashes the GPU.
+        // Using very high values will first lead to an ENOMEM but there might be a point when you get again an EINVAL.
 
         /// <summary>
         /// Creates a new instance of the <see cref="MMALResizerComponent"/> class that can be used to change the size
         /// and the pixel format of resulting frames. 
         /// </summary>
-        /// <param name="width">The width of the output frames. Value from 2 to 32767.</param>
-        /// <param name="height">The height of the output frames. Value from 2 to 32767.</param>
+        /// <param name="width">The width of the output frames. Value must be greater than 1.</param>
+        /// <param name="height">The height of the output frames. Value must be greater than 1.</param>
         /// <param name="handler"></param>
+        /// <exception cref="ArgumentOutOfRangeException"/>
         public MMALResizerComponent(int width, int height, ICaptureHandler handler)
             : base(MMAL_COMPONENT_DEFAULT_RESIZER, handler)
         {
@@ -32,29 +34,29 @@ namespace MMALSharp.Components
         }
 
         /// <summary>
-        /// Gets or sets the width of resulting frames. Value from 2 to 32767.
+        /// Gets or sets the width of resulting frames. Value must be greater than 1.
         /// </summary>
         public override int Width
         {
             get => _width;
             set
             {
-                if (value < 2 || value > 32767)
-                    throw new ArgumentOutOfRangeException(nameof(Width), value, "Width must be greater than 1 and smaller than 32768");
+                if (value < 2)
+                    throw new ArgumentOutOfRangeException(nameof(Width), value, "Width must be greater than 1");
                 _width = value;
             }
         }
 
         /// <summary>
-        /// Gets or sets the height of resulting frames. Value from 2 to 32767.
+        /// Gets or sets the height of resulting frames. Value must be greater than 1.
         /// </summary>
         public override int Height
         {
             get => _height;
             set
             {
-                if (value < 2 || value > 32767)
-                    throw new ArgumentOutOfRangeException(nameof(Height), value, "Height must be greater than 1 and smaller than 32768");
+                if (value < 2)
+                    throw new ArgumentOutOfRangeException(nameof(Height), value, "Height must be greater than 1");
                 _height = value;
             }
         }

--- a/src/MMALSharp/MMALCameraConfig.cs
+++ b/src/MMALSharp/MMALCameraConfig.cs
@@ -53,7 +53,7 @@ namespace MMALSharp
         /// Configure the light sensitivity of the sensor.
         /// </summary> 
         public static int ISO { get; set; }
-        
+
         /// <summary>
         /// Configure the exposure compensation of the camera. Doing so will produce a lighter/darker image beyond the recommended exposure.
         /// </summary>
@@ -127,7 +127,7 @@ namespace MMALSharp
         /// Displays the exposure, analogue and digital gains, and AWB settings used.
         /// </summary>
         public static bool StatsPass { get; set; }
-                
+
         /// <summary>
         /// Allows fine tuning of annotation options.
         /// </summary>
@@ -164,7 +164,7 @@ namespace MMALSharp
         /// The pixel format to use with the Preview renderer.
         /// </summary>
         public static MMALEncoding PreviewSubformat { get; set; } = MMALEncoding.I420;
-        
+
         /*
          * -----------------------------------------------------------------------------------------------------------
          * Camera video port specific properties.
@@ -185,7 +185,7 @@ namespace MMALSharp
         /// The Resolution to use for Video captures.
         /// </summary>
         public static Resolution VideoResolution { get; set; } = Resolution.As1080p;
-        
+
         /// <summary>
         /// Enable video stabilisation.
         /// </summary> 
@@ -200,7 +200,7 @@ namespace MMALSharp
         /// Specifies the number of frames after which a new I-frame is inserted in to the stream.
         /// </summary>
         public static int IntraPeriod { get; set; } = -1;
-                
+
         /// <summary>
         /// Represents the H.264 video profile you wish to use.
         /// </summary>
@@ -211,6 +211,10 @@ namespace MMALSharp
         /// </summary>
         public static MMALParametersVideo.MMAL_VIDEO_LEVEL_T VideoLevel { get; set; } = MMALParametersVideo.MMAL_VIDEO_LEVEL_T.MMAL_VIDEO_LEVEL_H264_4;
 
+        /// <summary>
+        /// Requires the video encoder not to modify the input images. 
+        /// </summary>
+        /// <remarks>http://www.jvcref.com/files/PI/documentation/ilcomponents/prop.html#OMX_IndexParamBrcmImmutableInput</remarks>
         public static bool ImmutableInput { get; set; } = true;
 
         /// <summary>
@@ -255,30 +259,27 @@ namespace MMALSharp
         /// The Resolution to use for Still captures.
         /// </summary>
         public static Resolution StillResolution { get; set; } = Resolution.As5MPixel;
-        
+
         /// <summary>
         /// The frame rate to use for Still captures.
         /// </summary>
-        public static MMAL_RATIONAL_T StillFramerate { get; set; } = new MMAL_RATIONAL_T(0, 1);        
+        public static MMAL_RATIONAL_T StillFramerate { get; set; } = new MMAL_RATIONAL_T(0, 1);
     }
-    
+
     /// <summary>
     /// Allows a user to adjust the colour of outputted frames.
     /// </summary>
     public struct ColourEffects
     {
-        private bool _enable;
-        private Color _color;
-
         /// <summary>
         /// Enable the Colour Effects functionality.
         /// </summary>
-        public bool Enable => _enable;
+        public bool Enable { get; }
 
         /// <summary>
         /// The <see cref="Color"/> to use.
         /// </summary>
-        public Color Color => _color;
+        public Color Color { get; }
 
         /// <summary>
         /// Initialises a new <see cref="ColourEffects"/> struct.
@@ -287,8 +288,8 @@ namespace MMALSharp
         /// <param name="color">The <see cref="Color"/> to use.</param>
         public ColourEffects(bool enable, Color color)
         {
-            _enable = enable;
-            _color = color;
+            Enable = enable;
+            Color = color;
         }
     }
 
@@ -297,27 +298,26 @@ namespace MMALSharp
     /// </summary>
     public struct Zoom
     {
-        private double _x, _y, _width, _height;
 
         /// <summary>
         /// The X coordinate between 0 - 1.0.
         /// </summary>
-        public double X => _x;
+        public double X { get; }
 
         /// <summary>
         /// The Y coordinate between 0 - 1.0.
         /// </summary>
-        public double Y => _y;
+        public double Y { get; }
 
         /// <summary>
         /// The Width value between 0 - 1.0.
         /// </summary>
-        public double Width => _width;
+        public double Width { get; }
 
         /// <summary>
         /// The Height value between 0 - 1.0.
         /// </summary>
-        public double Height => _height;
+        public double Height { get; }
 
         /// <summary>
         /// Intialises a new <see cref="Zoom"/> struct.
@@ -328,15 +328,17 @@ namespace MMALSharp
         /// <param name="height">The Height value.</param>
         public Zoom(double x, double y, double width, double height)
         {
-            _x = x;
-            _y = y;
-            _width = width;
-            _height = height;
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
         }
     }
 
     /// <summary>
-    /// The Stereoscopic mode code has mainly been added for completeness. It requires a Raspberry Pi Compute Module with two cameras connected. This functionality has not been tested.
+    /// The Stereoscopic mode code has mainly been added for completeness.
+    /// It requires a Raspberry Pi Compute Module with two cameras connected.
+    /// This functionality has not been tested.
     /// </summary>
     public class StereoMode
     {
@@ -344,7 +346,7 @@ namespace MMALSharp
         public int Decimate { get; set; }
         public int SwapEyes { get; set; }
     }
-    
+
     /// <summary>
     /// Represents an Exif tag for use with JPEG still captures.
     /// </summary>
@@ -387,7 +389,7 @@ namespace MMALSharp
     /// This will produce a textual overlay on image stills depending on the options enabled.
     /// </summary>
     public class AnnotateImage
-    {   
+    {
         /// <summary>
         /// Custom text to overlay on the stills capture.
         /// </summary>
@@ -469,16 +471,25 @@ namespace MMALSharp
         /// <summary>
         /// The <see cref="TimelapseMode"/> mode to use.
         /// </summary>
-        public TimelapseMode Mode { get; set; }        
+        public TimelapseMode Mode { get; set; }
     }
 
     /// <summary>
     /// The unit of time to use.
     /// </summary>
     public enum TimelapseMode
-    {        
+    {
+        /// <summary>
+        /// Uses milliseconds as unit of time. One hour equals 3'600'000 milliseconds.
+        /// </summary>
         Millisecond,
+        /// <summary>
+        /// Uses seconds as unit of time. One hour equals 3'600 seconds.
+        /// </summary>
         Second,
+        /// <summary>
+        /// Uses minutes as unit of time. One hour equals 60 minutes.
+        /// </summary>
         Minute
     }
 
@@ -487,17 +498,15 @@ namespace MMALSharp
     /// </summary>
     public struct Resolution : IComparable<Resolution>
     {
-        private int _width, _height;
-
         /// <summary>
         /// The width of the <see cref="Resolution"/> object.
         /// </summary>
-        public int Width => _width;
+        public int Width { get; }
 
         /// <summary>
         /// The height of the <see cref="Resolution"/> object.
         /// </summary>
-        public int Height => _height;
+        public int Height { get; }
 
         /// <summary>
         /// Creates a new instance of the <see cref="Resolution"/> class with the specified width and height.
@@ -506,8 +515,8 @@ namespace MMALSharp
         /// <param name="height"></param>
         public Resolution(int width, int height)
         {
-            _width = width;
-            _height = height;
+            Width = width;
+            Height = height;
         }
 
         /*
@@ -597,7 +606,7 @@ namespace MMALSharp
             {
                 return -1;
             }
-            
+
             if (this.Width > res.Width)
                 return 1;
 
@@ -613,10 +622,13 @@ namespace MMALSharp
         public Resolution Pad(int width = 32, int height = 16)
         {
             return new Resolution(MMALUtil.VCOS_ALIGN_UP(this.Width, width),
-                                  MMALUtil.VCOS_ALIGN_UP(this.Height, height));            
+                                  MMALUtil.VCOS_ALIGN_UP(this.Height, height));
         }
     }
 
+    /// <summary>
+    /// Defines the settings for a <see cref="MMALVideoRenderer"/> component.
+    /// </summary>
     public class PreviewConfiguration
     {
         /// <summary>
@@ -655,6 +667,9 @@ namespace MMALSharp
         public MMALParametersVideo.MMAL_DISPLAYMODE_T DisplayMode { get; set; }
     }
 
+    /// <summary>
+    /// Defines the settings for a <see cref="MMALOverlayRenderer"/> component.
+    /// </summary>
     public class PreviewOverlayConfiguration : PreviewConfiguration
     {
         /// <summary>

--- a/src/MMALSharp/Native/MMALEncodings.cs
+++ b/src/MMALSharp/Native/MMALEncodings.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace MMALSharp.Native
@@ -12,7 +13,11 @@ namespace MMALSharp.Native
 
     public static class MMALEncodingHelpers
     {
-        public static List<MMALEncoding> EncodingList => new List<MMALEncoding>
+        /// <summary>
+        /// Gets a list of all supported encodings.
+        /// Call <see cref="MMALPortExtensions.GetSupportedEncodings(MMALPortImpl)"/> to get supported encodings for a specific port.
+        /// </summary>
+        public static IReadOnlyCollection<MMALEncoding> EncodingList { get; } = new ReadOnlyCollection<MMALEncoding>(new List<MMALEncoding>
         {
             MMALEncoding.H264,
             MMALEncoding.MVC,
@@ -118,7 +123,7 @@ namespace MMALSharp.Native
             MMALEncoding.MMAL_COLOR_SPACE_BT470_2_M,
             MMALEncoding.MMAL_COLOR_SPACE_BT470_2_BG,
             MMALEncoding.MMAL_COLOR_SPACE_JFIF_Y16_255
-        };
+        });
 
         /// <summary>
         /// Parses an integer encoding value to an MMALEncoding object.
@@ -142,134 +147,134 @@ namespace MMALSharp.Native
             Internal
         }
 
-        public int EncodingVal { get; set; }
+        public int EncodingVal { get; }
 
-        public string EncodingName { get; set; }
+        public string EncodingName { get; }
 
-        public EncodingType EncType { get; set; }
+        public EncodingType EncType { get; }
 
-        public MMALEncoding(string s, EncodingType type)
+        private MMALEncoding(string s, EncodingType type)
         {
             this.EncodingVal = MMALUtil.MMAL_FOURCC(s);
             this.EncodingName = s;
             this.EncType = type;
         }
 
-        public MMALEncoding(int val, string name, EncodingType type)
+        private MMALEncoding(int val, string name, EncodingType type)
         {
             this.EncodingVal = val;
             this.EncodingName = name;
             this.EncType = type;
         }
 
-        public static MMALEncoding H264 = new MMALEncoding("H264", EncodingType.Video);
-        public static MMALEncoding MVC = new MMALEncoding("MVC ", EncodingType.Video);
-        public static MMALEncoding H263 = new MMALEncoding("H263", EncodingType.Video);
-        public static MMALEncoding MP4V = new MMALEncoding("MP4V", EncodingType.Video);
-        public static MMALEncoding MP2V = new MMALEncoding("MP2V", EncodingType.Video);
-        public static MMALEncoding MP1V = new MMALEncoding("MP1V", EncodingType.Video);
-        public static MMALEncoding WMV3 = new MMALEncoding("WMV3", EncodingType.Video);
-        public static MMALEncoding WMV2 = new MMALEncoding("WMV2", EncodingType.Video);
-        public static MMALEncoding WMV1 = new MMALEncoding("WMV1", EncodingType.Video);
-        public static MMALEncoding WVC1 = new MMALEncoding("WVC1", EncodingType.Video);
-        public static MMALEncoding VP8 = new MMALEncoding("VP8 ", EncodingType.Video);
-        public static MMALEncoding VP7 = new MMALEncoding("VP7 ", EncodingType.Video);
-        public static MMALEncoding VP6 = new MMALEncoding("VP6 ", EncodingType.Video);
-        public static MMALEncoding THEORA = new MMALEncoding("THEO", EncodingType.Video);
-        public static MMALEncoding SPARK = new MMALEncoding("SPRK", EncodingType.Video);
-        public static MMALEncoding MJPEG = new MMALEncoding("MJPG", EncodingType.Video);
-        public static MMALEncoding JPEG = new MMALEncoding("JPEG", EncodingType.Image);
-        public static MMALEncoding GIF = new MMALEncoding("GIF ", EncodingType.Image);
-        public static MMALEncoding PNG = new MMALEncoding("PNG ", EncodingType.Image);
-        public static MMALEncoding PPM = new MMALEncoding("PPM ", EncodingType.Image);
-        public static MMALEncoding TGA = new MMALEncoding("TGA ", EncodingType.Image);
-        public static MMALEncoding BMP = new MMALEncoding("BMP ", EncodingType.Image);
-        public static MMALEncoding I420 = new MMALEncoding("I420", EncodingType.PixelFormat);
-        public static MMALEncoding I420_SLICE = new MMALEncoding("S420", EncodingType.PixelFormat);
-        public static MMALEncoding YV12 = new MMALEncoding("YV12", EncodingType.PixelFormat);
-        public static MMALEncoding I422 = new MMALEncoding("I422", EncodingType.PixelFormat);
-        public static MMALEncoding I422_SLICE = new MMALEncoding("S422", EncodingType.PixelFormat);
-        public static MMALEncoding YUYV = new MMALEncoding("YUYV", EncodingType.PixelFormat);
-        public static MMALEncoding YVYU = new MMALEncoding("YVYU", EncodingType.PixelFormat);
-        public static MMALEncoding UYVY = new MMALEncoding("UYVY", EncodingType.PixelFormat);
-        public static MMALEncoding VYUY = new MMALEncoding("VYUY", EncodingType.PixelFormat);
-        public static MMALEncoding NV12 = new MMALEncoding("NV12", EncodingType.PixelFormat);
-        public static MMALEncoding NV21 = new MMALEncoding("NV21", EncodingType.PixelFormat);
-        public static MMALEncoding ARGB = new MMALEncoding("ARGB", EncodingType.PixelFormat);
-        public static MMALEncoding RGBA = new MMALEncoding("RGBA", EncodingType.PixelFormat);
-        public static MMALEncoding ABGR = new MMALEncoding("ABGR", EncodingType.PixelFormat);
-        public static MMALEncoding BGRA = new MMALEncoding("BGRA", EncodingType.PixelFormat);
-        public static MMALEncoding RGB16 = new MMALEncoding("RGB2", EncodingType.PixelFormat);
-        public static MMALEncoding RGB24 = new MMALEncoding("RGB3", EncodingType.PixelFormat);
-        public static MMALEncoding RGB32 = new MMALEncoding("RGB4", EncodingType.PixelFormat);
-        public static MMALEncoding BGR16 = new MMALEncoding("BGR2", EncodingType.PixelFormat);
-        public static MMALEncoding BGR24 = new MMALEncoding("BGR3", EncodingType.PixelFormat);
-        public static MMALEncoding BGR32 = new MMALEncoding("BGR4", EncodingType.PixelFormat);
-        public static MMALEncoding BAYER_SBGGR10P = new MMALEncoding("pBAA", EncodingType.PixelFormat);
-        public static MMALEncoding BAYER_SBGGR8 = new MMALEncoding("BA81", EncodingType.PixelFormat);
-        public static MMALEncoding BAYER_SBGGR12P = new MMALEncoding("BY12", EncodingType.PixelFormat);
-        public static MMALEncoding BAYER_SBGGR16 = new MMALEncoding("BYR2", EncodingType.PixelFormat);
-        public static MMALEncoding BAYER_SBGGR10DPCM8 = new MMALEncoding("bBA8", EncodingType.PixelFormat);
-        public static MMALEncoding YUVUV128 = new MMALEncoding("SAND", EncodingType.PixelFormat);
+        public static readonly MMALEncoding H264 = new MMALEncoding("H264", EncodingType.Video);
+        public static readonly MMALEncoding MVC = new MMALEncoding("MVC ", EncodingType.Video);
+        public static readonly MMALEncoding H263 = new MMALEncoding("H263", EncodingType.Video);
+        public static readonly MMALEncoding MP4V = new MMALEncoding("MP4V", EncodingType.Video);
+        public static readonly MMALEncoding MP2V = new MMALEncoding("MP2V", EncodingType.Video);
+        public static readonly MMALEncoding MP1V = new MMALEncoding("MP1V", EncodingType.Video);
+        public static readonly MMALEncoding WMV3 = new MMALEncoding("WMV3", EncodingType.Video);
+        public static readonly MMALEncoding WMV2 = new MMALEncoding("WMV2", EncodingType.Video);
+        public static readonly MMALEncoding WMV1 = new MMALEncoding("WMV1", EncodingType.Video);
+        public static readonly MMALEncoding WVC1 = new MMALEncoding("WVC1", EncodingType.Video);
+        public static readonly MMALEncoding VP8 = new MMALEncoding("VP8 ", EncodingType.Video);
+        public static readonly MMALEncoding VP7 = new MMALEncoding("VP7 ", EncodingType.Video);
+        public static readonly MMALEncoding VP6 = new MMALEncoding("VP6 ", EncodingType.Video);
+        public static readonly MMALEncoding THEORA = new MMALEncoding("THEO", EncodingType.Video);
+        public static readonly MMALEncoding SPARK = new MMALEncoding("SPRK", EncodingType.Video);
+        public static readonly MMALEncoding MJPEG = new MMALEncoding("MJPG", EncodingType.Video);
+        public static readonly MMALEncoding JPEG = new MMALEncoding("JPEG", EncodingType.Image);
+        public static readonly MMALEncoding GIF = new MMALEncoding("GIF ", EncodingType.Image);
+        public static readonly MMALEncoding PNG = new MMALEncoding("PNG ", EncodingType.Image);
+        public static readonly MMALEncoding PPM = new MMALEncoding("PPM ", EncodingType.Image);
+        public static readonly MMALEncoding TGA = new MMALEncoding("TGA ", EncodingType.Image);
+        public static readonly MMALEncoding BMP = new MMALEncoding("BMP ", EncodingType.Image);
+        public static readonly MMALEncoding I420 = new MMALEncoding("I420", EncodingType.PixelFormat);
+        public static readonly MMALEncoding I420_SLICE = new MMALEncoding("S420", EncodingType.PixelFormat);
+        public static readonly MMALEncoding YV12 = new MMALEncoding("YV12", EncodingType.PixelFormat);
+        public static readonly MMALEncoding I422 = new MMALEncoding("I422", EncodingType.PixelFormat);
+        public static readonly MMALEncoding I422_SLICE = new MMALEncoding("S422", EncodingType.PixelFormat);
+        public static readonly MMALEncoding YUYV = new MMALEncoding("YUYV", EncodingType.PixelFormat);
+        public static readonly MMALEncoding YVYU = new MMALEncoding("YVYU", EncodingType.PixelFormat);
+        public static readonly MMALEncoding UYVY = new MMALEncoding("UYVY", EncodingType.PixelFormat);
+        public static readonly MMALEncoding VYUY = new MMALEncoding("VYUY", EncodingType.PixelFormat);
+        public static readonly MMALEncoding NV12 = new MMALEncoding("NV12", EncodingType.PixelFormat);
+        public static readonly MMALEncoding NV21 = new MMALEncoding("NV21", EncodingType.PixelFormat);
+        public static readonly MMALEncoding ARGB = new MMALEncoding("ARGB", EncodingType.PixelFormat);
+        public static readonly MMALEncoding RGBA = new MMALEncoding("RGBA", EncodingType.PixelFormat);
+        public static readonly MMALEncoding ABGR = new MMALEncoding("ABGR", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BGRA = new MMALEncoding("BGRA", EncodingType.PixelFormat);
+        public static readonly MMALEncoding RGB16 = new MMALEncoding("RGB2", EncodingType.PixelFormat);
+        public static readonly MMALEncoding RGB24 = new MMALEncoding("RGB3", EncodingType.PixelFormat);
+        public static readonly MMALEncoding RGB32 = new MMALEncoding("RGB4", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BGR16 = new MMALEncoding("BGR2", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BGR24 = new MMALEncoding("BGR3", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BGR32 = new MMALEncoding("BGR4", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BAYER_SBGGR10P = new MMALEncoding("pBAA", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BAYER_SBGGR8 = new MMALEncoding("BA81", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BAYER_SBGGR12P = new MMALEncoding("BY12", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BAYER_SBGGR16 = new MMALEncoding("BYR2", EncodingType.PixelFormat);
+        public static readonly MMALEncoding BAYER_SBGGR10DPCM8 = new MMALEncoding("bBA8", EncodingType.PixelFormat);
+        public static readonly MMALEncoding YUVUV128 = new MMALEncoding("SAND", EncodingType.PixelFormat);
         /// <summary>
         /// An opaque buffer is a Broadcom specific format that references a GPU internal bitmap. It is typed as <see cref="EncodingType.Internal"/>.
         /// </summary>
         /// <remarks>https://www.raspberrypi.org/forums/viewtopic.php?t=53698</remarks>
-        public static MMALEncoding OPAQUE = new MMALEncoding("OPQV", EncodingType.Internal);
-        public static MMALEncoding EGL_IMAGE = new MMALEncoding("EGLI", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_UNSIGNED_BE = new MMALEncoding("PCMU", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_UNSIGNED_LE = new MMALEncoding("pcmu", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_SIGNED_BE = new MMALEncoding("PCMS", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_SIGNED_LE = new MMALEncoding("pcms", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_FLOAT_BE = new MMALEncoding("PCMF", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_FLOAT_LE = new MMALEncoding("pcmf", EncodingType.PixelFormat);
-        public static MMALEncoding PCM_UNSIGNED = PCM_UNSIGNED_LE;
-        public static MMALEncoding PCM_SIGNED = PCM_SIGNED_LE;
-        public static MMALEncoding PCM_FLOAT = PCM_FLOAT_LE;
-        public static MMALEncoding MP4A = new MMALEncoding("MP4A", EncodingType.Audio);
-        public static MMALEncoding MPGA = new MMALEncoding("MPGA", EncodingType.Audio);
-        public static MMALEncoding ALAW = new MMALEncoding("ALAW", EncodingType.Audio);
-        public static MMALEncoding MULAW = new MMALEncoding("ULAW", EncodingType.Audio);
-        public static MMALEncoding ADPCM_MS = new MMALEncoding("MS\x00\x02", EncodingType.Audio);
-        public static MMALEncoding ADPCM_IMA_MS = new MMALEncoding("MS\x00\x01", EncodingType.Audio);
-        public static MMALEncoding ADPCM_SWF = new MMALEncoding("ASWF", EncodingType.Audio);
-        public static MMALEncoding WMA1 = new MMALEncoding("WMA1", EncodingType.Audio);
-        public static MMALEncoding WMA2 = new MMALEncoding("WMA2", EncodingType.Audio);
-        public static MMALEncoding WMAP = new MMALEncoding("WMAP", EncodingType.Audio);
-        public static MMALEncoding WMAL = new MMALEncoding("WMAL", EncodingType.Audio);
-        public static MMALEncoding WMAV = new MMALEncoding("WMAV", EncodingType.Audio);
-        public static MMALEncoding AMRNB = new MMALEncoding("AMRN", EncodingType.Audio);
-        public static MMALEncoding AMRWB = new MMALEncoding("AMRW", EncodingType.Audio);
-        public static MMALEncoding AMRWBP = new MMALEncoding("AMRP", EncodingType.Audio);
-        public static MMALEncoding AC3 = new MMALEncoding("AC3 ", EncodingType.Audio);
-        public static MMALEncoding EAC3 = new MMALEncoding("EAC3", EncodingType.Audio);
-        public static MMALEncoding DTS = new MMALEncoding("DTS ", EncodingType.Audio);
-        public static MMALEncoding MLP = new MMALEncoding("MLP ", EncodingType.Audio);
-        public static MMALEncoding FLAC = new MMALEncoding("FLAC", EncodingType.Audio);
-        public static MMALEncoding VORBIS = new MMALEncoding("VORB", EncodingType.Audio);
-        public static MMALEncoding SPEEX = new MMALEncoding("SPX ", EncodingType.Audio);
-        public static MMALEncoding ATRAC3 = new MMALEncoding("ATR3", EncodingType.Audio);
-        public static MMALEncoding ATRACX = new MMALEncoding("ATRX", EncodingType.Audio);
-        public static MMALEncoding ATRACL = new MMALEncoding("ATRL", EncodingType.Audio);
-        public static MMALEncoding MIDI = new MMALEncoding("MIDI", EncodingType.Audio);
-        public static MMALEncoding EVRC = new MMALEncoding("EVRC", EncodingType.Audio);
-        public static MMALEncoding NELLYMOSER = new MMALEncoding("NELY", EncodingType.Audio);
-        public static MMALEncoding QCELP = new MMALEncoding("QCEL", EncodingType.Audio);
-        public static MMALEncoding MP4V_DIVX_DRM = new MMALEncoding("M4VD", EncodingType.Video);
-        public static MMALEncoding VARIANT_H264_DEFAULT = new MMALEncoding(0, "VARIANT_H264_DEFAULT", EncodingType.Video);
-        public static MMALEncoding VARIANT_H264_AVC1 = new MMALEncoding("AVC1", EncodingType.Video);
-        public static MMALEncoding VARIANT_H264_RAW = new MMALEncoding("RAW ", EncodingType.Video);
-        public static MMALEncoding VARIANT_MP4A_DEFAULT = new MMALEncoding(0, "VARIANT_MP4A_DEFAULT", EncodingType.Video);
-        public static MMALEncoding VARIANT_MP4A_ADTS = new MMALEncoding("ADTS", EncodingType.Video);
-        public static MMALEncoding MMAL_COLOR_SPACE_UNKNOWN = new MMALEncoding(0, "MMAL_COLOR_SPACE_UNKNOWN", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_ITUR_BT601 = new MMALEncoding("Y601", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_ITUR_BT709 = new MMALEncoding("Y709", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_JPEG_JFIF = new MMALEncoding("YJFI", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_FCC = new MMALEncoding("YFCC", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_SMPTE240M = new MMALEncoding("Y240", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_BT470_2_M = new MMALEncoding("Y__M", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_BT470_2_BG = new MMALEncoding("Y_BG", EncodingType.PixelFormat);
-        public static MMALEncoding MMAL_COLOR_SPACE_JFIF_Y16_255 = new MMALEncoding("YY16", EncodingType.PixelFormat);
+        public static readonly MMALEncoding OPAQUE = new MMALEncoding("OPQV", EncodingType.Internal);
+        public static readonly MMALEncoding EGL_IMAGE = new MMALEncoding("EGLI", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_UNSIGNED_BE = new MMALEncoding("PCMU", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_UNSIGNED_LE = new MMALEncoding("pcmu", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_SIGNED_BE = new MMALEncoding("PCMS", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_SIGNED_LE = new MMALEncoding("pcms", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_FLOAT_BE = new MMALEncoding("PCMF", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_FLOAT_LE = new MMALEncoding("pcmf", EncodingType.PixelFormat);
+        public static readonly MMALEncoding PCM_UNSIGNED = PCM_UNSIGNED_LE;
+        public static readonly MMALEncoding PCM_SIGNED = PCM_SIGNED_LE;
+        public static readonly MMALEncoding PCM_FLOAT = PCM_FLOAT_LE;
+        public static readonly MMALEncoding MP4A = new MMALEncoding("MP4A", EncodingType.Audio);
+        public static readonly MMALEncoding MPGA = new MMALEncoding("MPGA", EncodingType.Audio);
+        public static readonly MMALEncoding ALAW = new MMALEncoding("ALAW", EncodingType.Audio);
+        public static readonly MMALEncoding MULAW = new MMALEncoding("ULAW", EncodingType.Audio);
+        public static readonly MMALEncoding ADPCM_MS = new MMALEncoding("MS\x00\x02", EncodingType.Audio);
+        public static readonly MMALEncoding ADPCM_IMA_MS = new MMALEncoding("MS\x00\x01", EncodingType.Audio);
+        public static readonly MMALEncoding ADPCM_SWF = new MMALEncoding("ASWF", EncodingType.Audio);
+        public static readonly MMALEncoding WMA1 = new MMALEncoding("WMA1", EncodingType.Audio);
+        public static readonly MMALEncoding WMA2 = new MMALEncoding("WMA2", EncodingType.Audio);
+        public static readonly MMALEncoding WMAP = new MMALEncoding("WMAP", EncodingType.Audio);
+        public static readonly MMALEncoding WMAL = new MMALEncoding("WMAL", EncodingType.Audio);
+        public static readonly MMALEncoding WMAV = new MMALEncoding("WMAV", EncodingType.Audio);
+        public static readonly MMALEncoding AMRNB = new MMALEncoding("AMRN", EncodingType.Audio);
+        public static readonly MMALEncoding AMRWB = new MMALEncoding("AMRW", EncodingType.Audio);
+        public static readonly MMALEncoding AMRWBP = new MMALEncoding("AMRP", EncodingType.Audio);
+        public static readonly MMALEncoding AC3 = new MMALEncoding("AC3 ", EncodingType.Audio);
+        public static readonly MMALEncoding EAC3 = new MMALEncoding("EAC3", EncodingType.Audio);
+        public static readonly MMALEncoding DTS = new MMALEncoding("DTS ", EncodingType.Audio);
+        public static readonly MMALEncoding MLP = new MMALEncoding("MLP ", EncodingType.Audio);
+        public static readonly MMALEncoding FLAC = new MMALEncoding("FLAC", EncodingType.Audio);
+        public static readonly MMALEncoding VORBIS = new MMALEncoding("VORB", EncodingType.Audio);
+        public static readonly MMALEncoding SPEEX = new MMALEncoding("SPX ", EncodingType.Audio);
+        public static readonly MMALEncoding ATRAC3 = new MMALEncoding("ATR3", EncodingType.Audio);
+        public static readonly MMALEncoding ATRACX = new MMALEncoding("ATRX", EncodingType.Audio);
+        public static readonly MMALEncoding ATRACL = new MMALEncoding("ATRL", EncodingType.Audio);
+        public static readonly MMALEncoding MIDI = new MMALEncoding("MIDI", EncodingType.Audio);
+        public static readonly MMALEncoding EVRC = new MMALEncoding("EVRC", EncodingType.Audio);
+        public static readonly MMALEncoding NELLYMOSER = new MMALEncoding("NELY", EncodingType.Audio);
+        public static readonly MMALEncoding QCELP = new MMALEncoding("QCEL", EncodingType.Audio);
+        public static readonly MMALEncoding MP4V_DIVX_DRM = new MMALEncoding("M4VD", EncodingType.Video);
+        public static readonly MMALEncoding VARIANT_H264_DEFAULT = new MMALEncoding(0, "VARIANT_H264_DEFAULT", EncodingType.Video);
+        public static readonly MMALEncoding VARIANT_H264_AVC1 = new MMALEncoding("AVC1", EncodingType.Video);
+        public static readonly MMALEncoding VARIANT_H264_RAW = new MMALEncoding("RAW ", EncodingType.Video);
+        public static readonly MMALEncoding VARIANT_MP4A_DEFAULT = new MMALEncoding(0, "VARIANT_MP4A_DEFAULT", EncodingType.Video);
+        public static readonly MMALEncoding VARIANT_MP4A_ADTS = new MMALEncoding("ADTS", EncodingType.Video);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_UNKNOWN = new MMALEncoding(0, "MMAL_COLOR_SPACE_UNKNOWN", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_ITUR_BT601 = new MMALEncoding("Y601", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_ITUR_BT709 = new MMALEncoding("Y709", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_JPEG_JFIF = new MMALEncoding("YJFI", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_FCC = new MMALEncoding("YFCC", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_SMPTE240M = new MMALEncoding("Y240", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_BT470_2_M = new MMALEncoding("Y__M", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_BT470_2_BG = new MMALEncoding("Y_BG", EncodingType.PixelFormat);
+        public static readonly MMALEncoding MMAL_COLOR_SPACE_JFIF_Y16_255 = new MMALEncoding("YY16", EncodingType.PixelFormat);
 
     }
 

--- a/src/MMALSharp/Ports/MMALPortBase.cs
+++ b/src/MMALSharp/Ports/MMALPortBase.cs
@@ -565,6 +565,7 @@ namespace MMALSharp
         /// Release an output port buffer, get a new one from the queue and send it for processing.
         /// </summary>
         /// <param name="bufferImpl">A managed buffer object.</param>
+        /// <param name="eos">End of stream. Disables sending the next buffer after releasing the old one.</param>
         internal void ReleaseOutputBuffer(MMALBufferImpl bufferImpl, bool eos)
         {
             bufferImpl.Release();


### PR DESCRIPTION
Hi Ian,

like with all pull requests I added more documentation ( #37 ).
In addition to that I set more restrictive access modifiers in some cases.
Furthermore I added a parameter checking for `MMALResizerComponent` ( #51 ).

In `GenericExtensions.cs` I changed the writing of `float` and `integer` values to make it more obvious which multiplication operator we are using. And I changed the `float.ToByte()` method by multiplying with 255 instead of 256. This is the mathematically right solution if you have a proportional scale from 0 to 255.

Daniel