### PR TITLE
Fix for #71 - set flips on both ports

### DIFF
--- a/src/MMALSharp/MMALCameraExtensions.cs
+++ b/src/MMALSharp/MMALCameraExtensions.cs
@@ -846,7 +846,30 @@ namespace MMALSharp
         /// </summary>
         /// <param name="camera">The camera component.</param>
         /// <returns>The Flips value.</returns>
-        public static MMAL_PARAM_MIRROR_T GetFlips(this MMALCameraComponent camera)
+        public static MMAL_PARAM_MIRROR_T GetFlips(this MMALCameraComponent camera) => GetStillFlips(camera);
+
+        /// <summary>
+        /// Gets the Flips value currently being used by the video port.
+        /// </summary>
+        /// <param name="camera">The camera component.</param>
+        /// <returns>The Flips value.</returns>
+        public static MMAL_PARAM_MIRROR_T GetVideoFlips(this MMALCameraComponent camera)
+        {
+            MMAL_PARAMETER_MIRROR_T mirror = new MMAL_PARAMETER_MIRROR_T(
+                new MMAL_PARAMETER_HEADER_T(MMAL_PARAMETER_MIRROR, Marshal.SizeOf<MMAL_PARAMETER_MIRROR_T>()),
+                MMAL_PARAM_MIRROR_T.MMAL_PARAM_MIRROR_NONE);
+
+            MMALCheck(MMALPort.mmal_port_parameter_get(camera.VideoPort.Ptr, &mirror.Hdr), "Unable to get flips");
+
+            return mirror.Value;
+        }
+
+        /// <summary>
+        /// Gets the Flips value currently being used by the still port.
+        /// </summary>
+        /// <param name="camera">The camera component.</param>
+        /// <returns>The Flips value.</returns>
+        public static MMAL_PARAM_MIRROR_T GetStillFlips(this MMALCameraComponent camera)
         {
             MMAL_PARAMETER_MIRROR_T mirror = new MMAL_PARAMETER_MIRROR_T(
                 new MMAL_PARAMETER_HEADER_T(MMAL_PARAMETER_MIRROR, Marshal.SizeOf<MMAL_PARAMETER_MIRROR_T>()),
@@ -864,6 +887,7 @@ namespace MMALSharp
                 flips);
 
             MMALCheck(MMALPort.mmal_port_parameter_set(camera.StillPort.Ptr, &mirror.Hdr), "Unable to set flips");
+            MMALCheck(MMALPort.mmal_port_parameter_set(camera.VideoPort.Ptr, &mirror.Hdr), "Unable to set flips");
         }
 
         /// <summary>

--- a/tests/MMALSharp.Tests/ConfigurationTests.cs
+++ b/tests/MMALSharp.Tests/ConfigurationTests.cs
@@ -270,7 +270,9 @@ namespace MMALSharp.Tests
 
             MMALCameraConfig.Flips = flips;
             _fixture.MMALCamera.ConfigureCameraSettings();
-            Assert.True(_fixture.MMALCamera.Camera.GetFlips() == flips);
+            Assert.True(_fixture.MMALCamera.Camera.GetFlips() == flips &&
+                        _fixture.MMALCamera.Camera.GetStillFlips() == flips &&
+                        _fixture.MMALCamera.Camera.GetVideoFlips() == flips);
         }
 
         [Theory]


### PR DESCRIPTION
I've done reasonably similar to picamera and set both flips in the setflips call.
But I've also created a GetStillFlips and GetVideoFlips so they can be tested individually