### PR TITLE
Motioncapture

### DIFF
--- a/src/MMALSharp.Processing/Handlers/CircularBufferCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/CircularBufferCaptureHandler.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="CircularBufferCaptureHandler.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 

--- a/src/MMALSharp.Processing/Handlers/CircularBufferCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/CircularBufferCaptureHandler.cs
@@ -166,9 +166,10 @@ namespace MMALSharp.Handlers
         /// <summary>
         /// Call to start recording to FileStream.
         /// </summary>
+        /// <param name="initRecording">Optional Action to execute when recording starts, for example, to request an h.264 I-frame.</param>
         /// <param name="cancellationToken">When the token is canceled, <see cref="StopRecording"/> is called. If a token is not provided, the caller must stop the recording.</param>
         /// <returns>Task representing the recording process if a CancellationToken was provided, otherwise a completed Task.</returns>
-        public async Task StartRecording(CancellationToken cancellationToken = default)
+        public async Task StartRecording(Action initRecording = null, CancellationToken cancellationToken = default)
         {
             if (this.CurrentStream == null)
             {
@@ -176,6 +177,11 @@ namespace MMALSharp.Handlers
             }
 
             _recordToFileStream = true;
+
+            if (initRecording != null)
+            {
+                initRecording.Invoke();
+            }
 
             if(cancellationToken != CancellationToken.None)
             {

--- a/src/MMALSharp.Processing/Handlers/FileStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/FileStreamCaptureHandler.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="FileStreamCaptureHandler.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 

--- a/src/MMALSharp.Processing/Handlers/IMotionCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/IMotionCaptureHandler.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IMotionCaptureHandler.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 
@@ -23,8 +23,7 @@ namespace MMALSharp.Handlers
         /// </summary>
         /// <param name="config">The motion configuration.</param>
         /// <param name="onDetect">A callback for when motion is detected.</param>
-        /// <param name="onStopDetect">An optional callback for when the record duration has passed.</param>
-        void ConfigureMotionDetection(MotionConfig config, Action onDetect, Action onStopDetect = null);
+        void ConfigureMotionDetection(MotionConfig config, Action onDetect);
 
         /// <summary>
         /// Enables motion detection. When configured, this will instruct the capture handler to detect motion.

--- a/src/MMALSharp.Processing/Handlers/VideoStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/VideoStreamCaptureHandler.cs
@@ -29,7 +29,17 @@ namespace MMALSharp.Handlers
         /// Indicates whether this capture handler stores video timestamps.
         /// </summary>
         protected bool StoreVideoTimestamps { get; }
-        
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="VideoStreamCaptureHandler"/> class without provisions for writing to a file. Supports
+        /// subclasses in which file output is optional.
+        /// </summary>
+        public VideoStreamCaptureHandler()
+            : base()
+        {
+            this.StoreVideoTimestamps = false;
+        }
+
         /// <summary>
         /// Creates a new instance of the <see cref="VideoStreamCaptureHandler"/> class with the specified directory and filename extension.
         /// </summary>
@@ -56,6 +66,11 @@ namespace MMALSharp.Handlers
         /// <inheritdoc />
         public override void Process(ImageContext context)
         {
+            if (this.CurrentStream == null)
+            {
+                return;
+            }
+
             base.Process(context);
 
             if (this.StoreVideoTimestamps && context.Pts.HasValue)
@@ -77,6 +92,11 @@ namespace MMALSharp.Handlers
         /// <param name="stream">The <see cref="FileStream"/> to write to.</param>
         public void InitialiseMotionStore(Stream stream)
         {
+            if (this.CurrentStream == null)
+            {
+                return;
+            }
+
             this.MotionVectorStore = stream;
         }
 

--- a/src/MMALSharp.Processing/Handlers/VideoStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/VideoStreamCaptureHandler.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="VideoStreamCaptureHandler.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 

--- a/src/MMALSharp.Processing/Processors/Motion/FrameDiffAnalyser.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/FrameDiffAnalyser.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="FrameDiffAnalyser.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 

--- a/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
@@ -13,24 +13,32 @@ namespace MMALSharp.Processors.Motion
     public class MotionConfig
     {
         /// <summary>
-        /// How long should we record for when detected.
+        /// How long should we record for when motion is detected.
         /// </summary>
         public TimeSpan RecordDuration { get; set; }
 
         /// <summary>
-        /// The threshold to use.
+        /// The amount of change which will trigger a motion event.
         /// </summary>
         public int Threshold { get; set; }
 
         /// <summary>
+        /// The frequency at which the test frame is updated. The test frame is the baseline against
+        /// which the current frame is compared to detect motion.
+        /// </summary>
+        public TimeSpan TestFrameInterval { get; set; }
+
+        /// <summary>
         /// Creates a new instance of <see cref="MotionConfig"/>.
         /// </summary>
-        /// <param name="recordDuration">The record duration.</param>
-        /// <param name="threshold">The threshold.</param>
-        public MotionConfig(TimeSpan recordDuration, int threshold)
+        /// <param name="recordDuration">Recording duration. Use TimeSpan.Zero to record indefinitely (your code must tell the handler when to stop). Defaults to TimeSpan.Zero.</param>
+        /// <param name="threshold">Motion sensitivity threshold. The default is 130 (suitable for many indoor scenes).</param>
+        /// <param name="testFrameInterval">Frequency at which the test frame is updated. The default is 10 seconds.</param>
+        public MotionConfig(TimeSpan recordDuration = default, int threshold = 130, TimeSpan testFrameInterval = default)
         {
             this.RecordDuration = recordDuration;
             this.Threshold = threshold;
+            this.TestFrameInterval = testFrameInterval.Equals(TimeSpan.Zero) ? TimeSpan.FromSeconds(10) : testFrameInterval;
         }
     }
 }

--- a/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
@@ -13,11 +13,6 @@ namespace MMALSharp.Processors.Motion
     public class MotionConfig
     {
         /// <summary>
-        /// How long should we record for when motion is detected.
-        /// </summary>
-        public TimeSpan RecordDuration { get; set; }
-
-        /// <summary>
         /// The amount of change which will trigger a motion event.
         /// </summary>
         public int Threshold { get; set; }
@@ -31,12 +26,10 @@ namespace MMALSharp.Processors.Motion
         /// <summary>
         /// Creates a new instance of <see cref="MotionConfig"/>.
         /// </summary>
-        /// <param name="recordDuration">Recording duration. Use TimeSpan.Zero to record indefinitely (your code must tell the handler when to stop). Defaults to TimeSpan.Zero.</param>
         /// <param name="threshold">Motion sensitivity threshold. The default is 130 (suitable for many indoor scenes).</param>
         /// <param name="testFrameInterval">Frequency at which the test frame is updated. The default is 10 seconds.</param>
-        public MotionConfig(TimeSpan recordDuration = default, int threshold = 130, TimeSpan testFrameInterval = default)
+        public MotionConfig(int threshold = 130, TimeSpan testFrameInterval = default)
         {
-            this.RecordDuration = recordDuration;
             this.Threshold = threshold;
             this.TestFrameInterval = testFrameInterval.Equals(TimeSpan.Zero) ? TimeSpan.FromSeconds(10) : testFrameInterval;
         }

--- a/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="MotionConfig.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 

--- a/src/MMALSharp/MMALCamera.cs
+++ b/src/MMALSharp/MMALCamera.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="MMALCamera.cs" company="Techyian">
-// Copyright (c) Ian Auty. All rights reserved.
+// Copyright (c) Ian Auty and contributors. All rights reserved.
 // Licensed under the MIT License. Please see LICENSE.txt for License info.
 // </copyright>
 
@@ -481,12 +481,11 @@ namespace MMALSharp
         /// <param name="handler">The motion capture handler.</param>
         /// <param name="config">The motion configuration object.</param>
         /// <param name="onDetect">The callback when motion is detected.</param>
-        /// <param name="onStopDetect">An optional callback which is called when the record duration has passed.</param>
         /// <returns>The camera instance.</returns>
-        public MMALCamera WithMotionDetection(IMotionCaptureHandler handler, MotionConfig config, Action onDetect, Action onStopDetect = null)
+        public MMALCamera WithMotionDetection(IMotionCaptureHandler handler, MotionConfig config, Action onDetect)
         {
             MMALCameraConfig.InlineMotionVectors = true;
-            handler.ConfigureMotionDetection(config, onDetect, onStopDetect);
+            handler.ConfigureMotionDetection(config, onDetect);
             return this;
         }
 


### PR DESCRIPTION
Fixes #157

Ian, as before, I've only tested under .NET Core, but these are not especially complex changes.

Changes to make recording optional
* `CircularBufferCaptureHandler` constructor accepts `bufferSize` arg only
* `VideoStreamCaptureHandler` adds a parameterless constructor
* `FileStreamCaptureHandler` adds a parameterless constructor (with logged warning)
* Video and file handlers add safety checks to allow null `CurrentStream`

Change to `CircularBufferCaptureHandler` to address motion detection bug (issue 157)
* Calling `DisableMotionCapture` calls `FrameDiffAnalyser.ResetAnalyser()` (updates test frame)

Changes to `MotionConfig` to periodically update the test frame
* All constructor arguments optional
* Default `RecordDuration` is `TimeSpan.Zero` to record indefinitely after motion event
* For indefinite recording, consumer is responsible for stopping recording
* `Threshold` defaults to 130 (as per wiki suggestion for indoor use)
* New `TestFrameInterval` is the `TimeSpan` to refresh the test frame
* Default `TestFrameInterval` is 10 seconds

Changes to `FrameDiffAnalyser` to update the test frame
* New `Stopwatch` field `_testFrameAge` (never null, but not always running)
* When `Apply` finishes the full `TestFrame`, stopwatch is started
* When `FrameAnalyser` has a full frame, `TestFrameExpired()` can "steal" it
* `TestFrameExpired` checks elapsed time, updates test frame, restarts stopwatch

