### PR TITLE
FrameDiffAnalyser enhancements

### DIFF
--- a/src/MMALSharp.Common/ImageContext.cs
+++ b/src/MMALSharp.Common/ImageContext.cs
@@ -57,5 +57,10 @@ namespace MMALSharp.Common
         /// The timestamp value.
         /// </summary>
         public long? Pts { get; set; }
+        
+        /// <summary>
+        /// The pixel format stride.
+        /// </summary>
+        public int Stride { get; set; }
     }
 }

--- a/src/MMALSharp.Processing/Processors/Motion/FrameDiffAnalyser.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/FrameDiffAnalyser.cs
@@ -113,29 +113,26 @@ namespace MMALSharp.Processors.Motion
 
         private void PrepareTestFrame()
         {
-            using (var stream = new MemoryStream(this.WorkingData.ToArray()))
+            var frame = this.GetBlankBitmap();
+
+            if (_firstFrame)
             {
-                var frame = this.GetBlankBitmap();
+                // one-time collection of basic frame dimensions
+                _frameWidth = frame.Width;
+                _frameHeight = frame.Height;
+                _frameBpp = Image.GetPixelFormatSize(frame.PixelFormat) / 8;
+                (this.TestFrame, _frameStride) = this.ProcessWorkingData();
 
-                if (_firstFrame)
+                if(!string.IsNullOrWhiteSpace(this.MotionConfig.MotionMaskPathname))
                 {
-                    // one-time collection of basic frame dimensions
-                    _frameWidth = frame.Width;
-                    _frameHeight = frame.Height;
-                    _frameBpp = Image.GetPixelFormatSize(frame.PixelFormat) / 8;
-                    (this.TestFrame, _frameStride) = this.ProcessWorkingData();
-
-                    if(!string.IsNullOrWhiteSpace(this.MotionConfig.MotionMaskPathname))
-                    {
-                        this.PrepareMask();
-                    }
-
-                    _firstFrame = false;
+                    this.PrepareMask();
                 }
-                else
-                {
-                    this.TestFrame = this.ProcessWorkingData().bytes;
-                }
+
+                _firstFrame = false;
+            }
+            else
+            {
+                this.TestFrame = this.ProcessWorkingData().bytes;
             }
 
             if (this.MotionConfig.TestFrameInterval != TimeSpan.Zero)

--- a/src/MMALSharp.Processing/Processors/Motion/FrameDiffAnalyser.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/FrameDiffAnalyser.cs
@@ -22,15 +22,25 @@ namespace MMALSharp.Processors.Motion
     /// </summary>
     public class FrameDiffAnalyser : FrameAnalyser
     {
+        // When true, PrepareTestFrame does additional start-up processing
+        private bool _firstFrame = true;
+
+        // Frame dimensions collected when the first full frame is complete
+        private int _frameWidth;
+        private int _frameHeight;
+        private int _frameStride;
+        private int _frameBpp;
+
+        private byte[] _mask;
         private Stopwatch _testFrameAge;
-        
+
         internal Action OnDetect { get; set; }
 
         /// <summary>
-        /// Working storage for the Test Frame. This is the image we are comparing against new incoming frames.
+        ///  This is the image we are comparing against new incoming frames.
         /// </summary>
-        protected List<byte> TestFrame { get; set; }
-        
+        protected byte[] TestFrame { get; set; }
+
         /// <summary>
         /// Indicates whether we have a full test frame.
         /// </summary>
@@ -53,7 +63,6 @@ namespace MMALSharp.Processors.Motion
         /// <param name="onDetect">A callback when changes are detected.</param>
         public FrameDiffAnalyser(MotionConfig config, Action onDetect)
         {
-            this.TestFrame = new List<byte>();
             this.MotionConfig = config;
             this.OnDetect = onDetect;
 
@@ -65,35 +74,27 @@ namespace MMALSharp.Processors.Motion
         {
             this.ImageContext = context;
 
-            if (this.FullTestFrame)
-            {
-                MMALLog.Logger.LogDebug("Have full test frame.");
-                
-                // If we have a full test frame stored then we can start storing subsequent frame data to check.
-                base.Apply(context);
-            }
-            else
-            {
-                this.TestFrame.AddRange(context.Data);
+            base.Apply(context);
 
+            if (!this.FullTestFrame)
+            {
                 if (context.Eos)
                 {
                     this.FullTestFrame = true;
-
-                    if(this.MotionConfig.TestFrameInterval != TimeSpan.Zero)
-                    {
-                        _testFrameAge.Restart();
-                    }
-
+                    this.PrepareTestFrame();
                     MMALLog.Logger.LogDebug("EOS reached for test frame.");
                 }
             }
-
-            if (this.FullFrame && !TestFrameExpired())
+            else
             {
-                MMALLog.Logger.LogDebug("Have full frame, checking for changes.");
+                MMALLog.Logger.LogDebug("Have full test frame.");
 
-                this.CheckForChanges(this.OnDetect);
+                if (this.FullFrame && !this.TestFrameExpired())
+                {
+                    MMALLog.Logger.LogDebug("Have full frame, checking for changes.");
+
+                    this.CheckForChanges(this.OnDetect);
+                }
             }
         }
 
@@ -102,7 +103,7 @@ namespace MMALSharp.Processors.Motion
         /// </summary>
         public void ResetAnalyser()
         {
-            this.TestFrame = new List<byte>();
+            this.TestFrame = null;
             this.WorkingData = new List<byte>();
             this.FullFrame = false;
             this.FullTestFrame = false;
@@ -110,29 +111,84 @@ namespace MMALSharp.Processors.Motion
             _testFrameAge.Reset();
         }
 
+        private void PrepareTestFrame()
+        {
+            using (var stream = new MemoryStream(this.WorkingData.ToArray()))
+            {
+                var frame = this.GetBlankBitmap();
+
+                if (_firstFrame)
+                {
+                    // one-time collection of basic frame dimensions
+                    _frameWidth = frame.Width;
+                    _frameHeight = frame.Height;
+                    _frameBpp = Image.GetPixelFormatSize(frame.PixelFormat) / 8;
+                    (this.TestFrame, _frameStride) = this.ProcessWorkingData();
+
+                    if(!string.IsNullOrWhiteSpace(this.MotionConfig.MotionMaskPathname))
+                    {
+                        this.PrepareMask();
+                    }
+
+                    _firstFrame = false;
+                }
+                else
+                {
+                    this.TestFrame = this.ProcessWorkingData().bytes;
+                }
+            }
+
+            if (this.MotionConfig.TestFrameInterval != TimeSpan.Zero)
+            {
+                _testFrameAge.Restart();
+            }
+        }
+
+        private void PrepareMask()
+        {
+            using (var fs = new FileStream(this.MotionConfig.MotionMaskPathname, FileMode.Open, FileAccess.Read))
+            using (var mask = new Bitmap(fs))
+            {
+                // Verify it matches our frame dimensions
+                var maskBpp = Image.GetPixelFormatSize(mask.PixelFormat) / 8;
+                if (mask.Width != _frameWidth || mask.Height != _frameHeight || maskBpp != _frameBpp)
+                {
+                    throw new Exception("Motion-detection mask must match raw stream width, height, and format (bits per pixel)");
+                }
+
+                // Store the byte array
+                BitmapData bmpData = null;
+                try
+                {
+                    bmpData = mask.LockBits(new Rectangle(0, 0, mask.Width, mask.Height), ImageLockMode.ReadOnly, mask.PixelFormat);
+                    var pNative = bmpData.Scan0;
+                    int size = bmpData.Stride * mask.Height;
+                    _mask = new byte[size];
+                    Marshal.Copy(pNative, _mask, 0, size);
+                }
+                finally
+                {
+                    mask.UnlockBits(bmpData);
+                }
+            }
+        }
+
         private bool TestFrameExpired()
         {
-            if(this.MotionConfig.TestFrameInterval == TimeSpan.Zero || _testFrameAge.Elapsed < this.MotionConfig.TestFrameInterval)
+            if (this.MotionConfig.TestFrameInterval == TimeSpan.Zero || _testFrameAge.Elapsed < this.MotionConfig.TestFrameInterval)
             {
                 return false;
             }
 
             MMALLog.Logger.LogDebug("Have full frame, updating test frame.");
-
-            this.TestFrame = this.WorkingData;
-            this.WorkingData = new List<byte>();
-
-            _testFrameAge.Restart();
-
+            this.PrepareTestFrame();
             return true;
         }
 
         private void CheckForChanges(Action onDetect)
         {
-            this.PrepareDifferenceImage(this.ImageContext, this.MotionConfig.Threshold);
-
             var diff = this.Analyse();
-            
+
             if (diff >= this.MotionConfig.Threshold)
             {
                 MMALLog.Logger.LogInformation($"Motion detected! Frame difference {diff}.");
@@ -140,264 +196,131 @@ namespace MMALSharp.Processors.Motion
             }
         }
 
-        private Bitmap LoadBitmap(MemoryStream stream)
+        private (byte[] bytes, int stride) ProcessWorkingData()
         {
-            if (this.ImageContext.Raw)
+            var bitmap = this.GetBlankBitmap();
+            BitmapData bmpData = null;
+            try
             {
-                PixelFormat format = default;
-
-                // RGB16 doesn't appear to be supported by GDI?
-                if (this.ImageContext.PixelFormat == MMALEncoding.RGB24)
-                {
-                    format = PixelFormat.Format24bppRgb;
-                }
-
-                if (this.ImageContext.PixelFormat == MMALEncoding.RGB32)
-                {
-                    format = PixelFormat.Format32bppRgb;
-                }
-
-                if (this.ImageContext.PixelFormat == MMALEncoding.RGBA)
-                {
-                    format = PixelFormat.Format32bppArgb;
-                }
-
-                if (format == default)
-                {
-                    throw new Exception("Unsupported pixel format for Bitmap");
-                }
-
-                return new Bitmap(this.ImageContext.Resolution.Width, this.ImageContext.Resolution.Height, format);
+                bmpData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadOnly, bitmap.PixelFormat);
+                var workingData = this.WorkingData.ToArray();
+                var pNative = bmpData.Scan0;
+                Marshal.Copy(workingData, 0, pNative, workingData.Length);
+                int size = bmpData.Stride * bitmap.Height;
+                var bytes = new byte[size];
+                Marshal.Copy(pNative, bytes, 0, size);
+                return (bytes, bmpData.Stride);
             }
-            
-            return new Bitmap(stream);
+            finally
+            {
+                bitmap?.UnlockBits(bmpData);
+            }
         }
 
-        private void InitBitmapData(BitmapData bmpData, byte[] data)
+        private Bitmap GetBlankBitmap()
         {
-            var pNative = bmpData.Scan0;
-            Marshal.Copy(data, 0, pNative, data.Length);
+            PixelFormat format = default;
+
+            // RGB16 doesn't appear to be supported by GDI?
+            if (this.ImageContext.PixelFormat == MMALEncoding.RGB24)
+            {
+                format = PixelFormat.Format24bppRgb;
+            }
+
+            if (this.ImageContext.PixelFormat == MMALEncoding.RGB32)
+            {
+                format = PixelFormat.Format32bppRgb;
+            }
+
+            if (this.ImageContext.PixelFormat == MMALEncoding.RGBA)
+            {
+                format = PixelFormat.Format32bppArgb;
+            }
+
+            if (format == default)
+            {
+                throw new Exception("Unsupported pixel format for Bitmap");
+            }
+
+            return new Bitmap(this.ImageContext.Resolution.Width, this.ImageContext.Resolution.Height, format);
         }
 
         private int Analyse()
         {
-            using (var testMemStream = new MemoryStream(this.TestFrame.ToArray()))
-            using (var currentMemStream = new MemoryStream(this.WorkingData.ToArray()))
-            using (var testBmp = this.LoadBitmap(testMemStream))
-            using (var currentBmp = this.LoadBitmap(currentMemStream))
+            var quadA = new Rectangle(0, 0, _frameWidth / 2, _frameHeight / 2);
+            var quadB = new Rectangle(_frameWidth / 2, 0, _frameWidth / 2, _frameHeight / 2);
+            var quadC = new Rectangle(0, _frameHeight / 2, _frameWidth / 2, _frameHeight / 2);
+            var quadD = new Rectangle(_frameWidth / 2, _frameHeight / 2, _frameWidth / 2, _frameHeight / 2);
+
+            var currentBytes = this.ProcessWorkingData().bytes;
+
+            int diff = 0;
+
+            var t1 = Task.Run(() =>
             {
-                var testBmpData = testBmp.LockBits(new Rectangle(0, 0, testBmp.Width, testBmp.Height), System.Drawing.Imaging.ImageLockMode.ReadWrite, testBmp.PixelFormat);
-                var currentBmpData = currentBmp.LockBits(new Rectangle(0, 0, currentBmp.Width, currentBmp.Height), System.Drawing.Imaging.ImageLockMode.ReadWrite, currentBmp.PixelFormat);
+                diff += this.CheckDiff(quadA, currentBytes);
+            });
+            var t2 = Task.Run(() =>
+            {
+                diff += this.CheckDiff(quadB, currentBytes);
+            });
+            var t3 = Task.Run(() =>
+            {
+                diff += this.CheckDiff(quadC, currentBytes);
+            });
+            var t4 = Task.Run(() =>
+            {
+                diff += this.CheckDiff(quadD, currentBytes);
+            });
 
-                if (this.ImageContext.Raw)
-                {
-                    this.InitBitmapData(testBmpData, this.TestFrame.ToArray());
-                    this.InitBitmapData(currentBmpData, this.WorkingData.ToArray());
-                }
+            Task.WaitAll(t1, t2, t3, t4);
 
-                var quadA = new Rectangle(0, 0, testBmpData.Width / 2, testBmpData.Height / 2);
-                var quadB = new Rectangle(testBmpData.Width / 2, 0, testBmpData.Width / 2, testBmpData.Height / 2);
-                var quadC = new Rectangle(0, testBmpData.Height / 2, testBmpData.Width / 2, testBmpData.Height / 2);
-                var quadD = new Rectangle(testBmpData.Width / 2, testBmpData.Height / 2, testBmpData.Width / 2, testBmpData.Height / 2);
-
-                int diff = 0;
-
-                var bpp = Image.GetPixelFormatSize(testBmp.PixelFormat) / 8;
-
-                var t1 = Task.Run(() =>
-                {
-                    diff += this.CheckDiff(quadA, testBmpData, currentBmpData, bpp, this.MotionConfig.Threshold);
-                });
-                var t2 = Task.Run(() =>
-                {
-                    diff += this.CheckDiff(quadB, testBmpData, currentBmpData, bpp, this.MotionConfig.Threshold);
-                });
-                var t3 = Task.Run(() =>
-                {
-                    diff += this.CheckDiff(quadC, testBmpData, currentBmpData, bpp, this.MotionConfig.Threshold);
-                });
-                var t4 = Task.Run(() =>
-                {
-                    diff += this.CheckDiff(quadD, testBmpData, currentBmpData, bpp, this.MotionConfig.Threshold);
-                });
-
-                Task.WaitAll(t1, t2, t3, t4);
-
-                testBmp.UnlockBits(testBmpData);
-                currentBmp.UnlockBits(currentBmpData);
-
-                return diff;
-            }
+            return diff;
         }
 
-        private void PrepareDifferenceImage(ImageContext context, int threshold)
+        private int CheckDiff(Rectangle quad, byte[] currentFrame)
         {
-            BitmapData bmpData = null;
-            IntPtr pNative = IntPtr.Zero;
-            int bytes;
-            byte[] store = null;
+            int diff = 0;
 
-            using (var ms = new MemoryStream(context.Data))
-            using (var bmp = this.LoadBitmap(ms))
+            for (int column = quad.X; column < quad.X + quad.Width; column++)
             {
-                bmpData = bmp.LockBits(new Rectangle(0, 0,
-                        bmp.Width,
-                        bmp.Height),
-                    ImageLockMode.ReadWrite,
-                    bmp.PixelFormat);
-
-                if (context.Raw)
+                for (int row = quad.Y; row < quad.Y + quad.Height; row++)
                 {
-                    this.InitBitmapData(bmpData, ms.ToArray());
-                }
+                    var index = (column * _frameBpp) + (row * _frameStride);
 
-                pNative = bmpData.Scan0;
-
-                // Split image into 4 quadrants and process individually.
-                var quadA = new Rectangle(0, 0, bmpData.Width / 2, bmpData.Height / 2);
-                var quadB = new Rectangle(bmpData.Width / 2, 0, bmpData.Width / 2, bmpData.Height / 2);
-                var quadC = new Rectangle(0, bmpData.Height / 2, bmpData.Width / 2, bmpData.Height / 2);
-                var quadD = new Rectangle(bmpData.Width / 2, bmpData.Height / 2, bmpData.Width / 2, bmpData.Height / 2);
-
-                bytes = bmpData.Stride * bmp.Height;
-
-                var rgbValues = new byte[bytes];
-
-                // Copy the RGB values into the array.
-                Marshal.Copy(pNative, rgbValues, 0, bytes);
-
-                var bpp = Image.GetPixelFormatSize(bmp.PixelFormat) / 8;
-
-                var t1 = Task.Run(() =>
-                {
-                    this.ApplyThreshold(quadA, bmpData, bpp, threshold);
-                });
-                var t2 = Task.Run(() =>
-                {
-                    this.ApplyThreshold(quadB, bmpData, bpp, threshold);
-                });
-                var t3 = Task.Run(() =>
-                {
-                    this.ApplyThreshold(quadC, bmpData, bpp, threshold);
-                });
-                var t4 = Task.Run(() =>
-                {
-                    this.ApplyThreshold(quadD, bmpData, bpp, threshold);
-                });
-
-                Task.WaitAll(t1, t2, t3, t4);
-
-                if (context.Raw)
-                {
-                    store = new byte[bytes];
-                    Marshal.Copy(pNative, store, 0, bytes);
-                }
-
-                bmp.UnlockBits(bmpData);
-            }
-
-            context.Data = store;
-        }
-
-        private void ApplyThreshold(Rectangle quad, BitmapData bmpData, int pixelDepth, int threshold)
-        {
-            unsafe
-            {
-                // Declare an array to hold the bytes of the bitmap.
-                var stride = bmpData.Stride;
-
-                byte* ptr1 = (byte*)bmpData.Scan0;
-
-                for (int column = quad.X; column < quad.X + quad.Width; column++)
-                {
-                    for (int row = quad.Y; row < quad.Y + quad.Height; row++)
+                    if(_mask != null)
                     {
-                        var rgb1 = ptr1[(column * pixelDepth) + (row * stride)] +
-                                   ptr1[(column * pixelDepth) + (row * stride) + 1] +
-                                   ptr1[(column * pixelDepth) + (row * stride) + 2];
+                        var rgbMask = _mask[index] + _mask[index + 1] + _mask[index + 2];
 
-                        if (rgb1 > threshold)
+                        if (rgbMask == 0)
                         {
-                            ptr1[(column * pixelDepth) + (row * stride)] = 255;
-                            ptr1[(column * pixelDepth) + (row * stride) + 1] = 255;
-                            ptr1[(column * pixelDepth) + (row * stride) + 2] = 255;
-                        }
-                        else
-                        {
-                            ptr1[(column * pixelDepth) + (row * stride)] = 0;
-                            ptr1[(column * pixelDepth) + (row * stride) + 1] = 0;
-                            ptr1[(column * pixelDepth) + (row * stride) + 2] = 0;
-                        }
-                    }
-                }
-            }
-        }
-
-        private int CheckDiff(Rectangle quad, BitmapData bmpData, BitmapData bmpData2, int pixelDepth, int threshold)
-        {
-            unsafe
-            {
-                var stride1 = bmpData.Stride;
-                var stride2 = bmpData2.Stride;
-
-                byte* ptr1 = (byte*)bmpData.Scan0;
-                byte* ptr2 = (byte*)bmpData2.Scan0;
-              
-                int diff = 0;
-                int lowestX = 0, highestX = 0, lowestY = 0, highestY = 0;
-
-                for (int column = quad.X; column < quad.X + quad.Width; column++)
-                {
-                    for (int row = quad.Y; row < quad.Y + quad.Height; row++)
-                    {
-                        var rgb1 = ptr1[(column * pixelDepth) + (row * stride1)] +
-                        ptr1[(column * pixelDepth) + (row * stride1) + 1] +
-                        ptr1[(column * pixelDepth) + (row * stride1) + 2];
-
-                        var rgb2 = ptr2[(column * pixelDepth) + (row * stride2)] +
-                        ptr2[(column * pixelDepth) + (row * stride2) + 1] +
-                        ptr2[(column * pixelDepth) + (row * stride2) + 2];
-                        
-                        if (rgb2 - rgb1 > threshold)
-                        {
-                            diff++;
-
-                            if (row < lowestY || lowestY == 0)
-                            {
-                                lowestY = row;
-                            }
-
-                            if (row > highestY)
-                            {
-                                highestY = row;
-                            }
-
-                            if (column < lowestX || lowestX == 0)
-                            {
-                                lowestX = column;
-                            }
-
-                            if (column > highestX)
-                            {
-                                highestX = column;
-                            }
-                        }
-
-                        // If the threshold has been exceeded, we want to exit from this method immediately for performance reasons.
-                        if (diff > threshold)
-                        {
-                            break;
+                            continue;
                         }
                     }
 
-                    if (diff > threshold)
+                    var rgb1 = TestFrame[index] + TestFrame[index + 1] + TestFrame[index + 2];
+
+                    var rgb2 = currentFrame[index] + currentFrame[index + 1] + currentFrame[index + 2];
+
+                    if (rgb2 - rgb1 > MotionConfig.Threshold)
                     {
-                        break;
+                        diff++;
+                    }
+
+                    // If the threshold has been exceeded, we want to exit from this method immediately for performance reasons.
+                    if (diff > MotionConfig.Threshold)
+                    {
+                        return diff;
                     }
                 }
 
-                return diff;
+                if (diff > MotionConfig.Threshold)
+                {
+                    return diff;
+                }
             }
+
+            return diff;
         }
     }
 }

--- a/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
+++ b/src/MMALSharp.Processing/Processors/Motion/MotionConfig.cs
@@ -24,14 +24,22 @@ namespace MMALSharp.Processors.Motion
         public TimeSpan TestFrameInterval { get; set; }
 
         /// <summary>
+        /// The name of a BMP file to apply as a motion-detection mask. The file must match the raw stream's
+        /// width, height, and color depth. Black pixels (RGB 0,0,0) are not tested for motion.
+        /// </summary>
+        public string MotionMaskPathname { get; set; }
+
+        /// <summary>
         /// Creates a new instance of <see cref="MotionConfig"/>.
         /// </summary>
         /// <param name="threshold">Motion sensitivity threshold. The default is 130 (suitable for many indoor scenes).</param>
         /// <param name="testFrameInterval">Frequency at which the test frame is updated. The default is 10 seconds.</param>
-        public MotionConfig(int threshold = 130, TimeSpan testFrameInterval = default)
+        /// <param name="motionMaskPathname">Pathname to an optional motion-detection mask bitmap.</param>
+        public MotionConfig(int threshold = 130, TimeSpan testFrameInterval = default, string motionMaskPathname = null)
         {
             this.Threshold = threshold;
             this.TestFrameInterval = testFrameInterval.Equals(TimeSpan.Zero) ? TimeSpan.FromSeconds(10) : testFrameInterval;
+            this.MotionMaskPathname = motionMaskPathname;
         }
     }
 }

--- a/src/MMALSharp/Callbacks/PortCallbackHandler.cs
+++ b/src/MMALSharp/Callbacks/PortCallbackHandler.cs
@@ -87,7 +87,8 @@ namespace MMALSharp.Callbacks
                 Encoding = this.WorkingPort.EncodingType,
                 PixelFormat = this.WorkingPort.PixelFormat,
                 Raw = this.WorkingPort.EncodingType.EncType == MMALEncoding.EncodingType.PixelFormat,
-                Pts = pts
+                Pts = pts,
+                Stride = MMALUtil.mmal_encoding_width_to_stride(WorkingPort.PixelFormat?.EncodingVal ?? this.WorkingPort.EncodingType.EncodingVal, this.WorkingPort.Resolution.Width)
             });
 
             if (eos)

--- a/src/MMALSharp/Native/MMALUtil.cs
+++ b/src/MMALSharp/Native/MMALUtil.cs
@@ -102,7 +102,7 @@ namespace MMALSharp.Native
         public static extern uint mmal_encoding_stride_to_width(uint encoding, uint stride);
 
         [DllImport("libmmal.so", EntryPoint = "mmal_encoding_width_to_stride", CallingConvention = CallingConvention.Cdecl)]
-        public static extern uint mmal_encoding_width_to_stride(uint encoding, uint width);
+        public static extern int mmal_encoding_width_to_stride(int encoding, int width);
 
         [DllImport("libmmal.so", EntryPoint = "mmal_encoding_get_slice_variant", CallingConvention = CallingConvention.Cdecl)]
         public static extern uint mmal_encoding_get_slice_variant(uint encoding);


### PR DESCRIPTION
Fixes #161 

These are the changes discussed in #161 -- I noted it's a fairly extensive (but simple) overhaul, so I'll walk through all the details of anything which changed, top to bottom. More to explain my thinking, none of the code is complicated.

**`MotionConfig`** 
There is one new string property, `MotionMaskPathname`, which is optional. It must be a BMP that matches the raw stream width, height, and color depth. Black pixels disable motion detection.

**`FrameDiffAnalyser`**
Several private fields have been added. `_firstFrame` starts out true and controls some basic chores once the first full frame has been collected. Instead of constantly pulling the bitmap dimensions, I just store them once, they'll never change for the raw motion detection stream (this actually had a measurable difference). Finally there is the `_mask`, and like the `TestFrame` we only store the `byte[]` data.

**`Apply`** and **`PrepareTestFrame`**
Now the class uses the underlying `FrameAnalyser` buffer exclusively. The changes there are pretty self-explanatory. `PrepareTestFrame` does all the work now. The call to `GetBlankBitmap` is the format-based stuff that used to be `LoadBitmap` -- in this class the stream version at the end was never used, so the only thing the method ever did was returned a new empty bitmap, so I just renamed it for clarity. If this is the first frame, it stores dimensions, then stores the frame's bytes to the `TestFrame` property via the new `ProcessWorkingData` method, and if a mask is defined, `PrepareMask` does a one-time setup of that. On subsequent calls, it just stores the bytes.

**`PrepareMask`**
Pretty simple. It loads the mask file, ensures the dimensions match, then stores the bytes to an array. I originally did this in the constructor, but I dislike putting operations like file I/O into a constructor, and I had other on-the-first-frame things to do anyway.

**`CheckForChanges`**
As mentioned in the issue, the extra code that was here (which looked like an older motion detection WIP) was unnecessary, so now this is just a call to `Analyse` and responding if the difference threshold is exceeded.

**`ProcessWorkingData`**
Since this revision is only ever concerned with managed byte arrays, that's basically what this does. There is an oddity here I don't understand -- you can see it calls `Marshal.Copy` twice -- once to put the `WorkingData` array into the bitmap buffer, then again to copy the bitmap buffer to the array that is returned. I don't understand why, but the `WorkingData` array contents are _not_ the same as the array read back out of the `Bitmap`. It works, and I'm hoping you can tell me what sort of witchcraft is at work there, I wouldn't have expected a memory copy to have side-effects, and not doing this definitely does not work. (That also answers the question I had in the related issue -- I wondered if conversion to a `Bitmap` was necessary at all, and the answer is apparently Yes.)

**`Analyse`**
Finally we reach the new slim, trim `Analyse` class. It's self-explanatory -- we set up the quads the same way (but using the stored dimension fields), the current frame bytes are pulled from `ProcessWorkingData`, then we run the `CheckDiff` calls -- which only need the quad and the current frame bytes, everything else is class-level fields / props. No locking, no streams, etc.

**`CheckDiff`**
No need for unsafe, this runs completely against managed arrays. We calculate the index (same for all the arrays) then check the `_mask` array first. If the pixel is black, we `continue`. Otherwise it's the same algorithm to compare the test frame against the current frame. I got rid of some `if` blocks that didn't do anything.

Masking works, I tested by loading one that was half black, half white, which made it easy to see when motion was triggered as I moved my hand across the field of view. So, nothing too complicated or crazy, almost more of a cleanup pass really, apart from switching to all managed arrays.

This has been quite entertaining.

