### PR TITLE
On-demand images, take two

### DIFF
--- a/src/MMALSharp.Processing/Handlers/IFileStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/IFileStreamCaptureHandler.cs
@@ -16,6 +16,11 @@ namespace MMALSharp.Handlers
         void NewFile();
 
         /// <summary>
+        /// The callback handler has received an end-of-stream marker.
+        /// </summary>
+        void NewFrame();
+
+        /// <summary>
         /// Gets the filepath that a FileStream points to.
         /// </summary>
         /// <returns>The filepath.</returns>

--- a/src/MMALSharp.Processing/Handlers/ImageStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/ImageStreamCaptureHandler.cs
@@ -13,18 +13,22 @@ namespace MMALSharp.Handlers
     public class ImageStreamCaptureHandler : FileStreamCaptureHandler
     {
         /// <summary>
-        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified directory and filename extension.
+        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified directory and filename extension. Filenames will be in the
+        /// format defined by the <see cref="FilenameDateTimeFormat"/> property.
         /// </summary>
         /// <param name="directory">The directory to save captured images.</param>
         /// <param name="extension">The filename extension for saving files.</param>
-        public ImageStreamCaptureHandler(string directory, string extension)
-            : base(directory, extension) { }
+        /// <param name="continuousCapture">When true, every frame is written to a file.</param>
+        public ImageStreamCaptureHandler(string directory, string extension, bool continuousCapture = true)
+            : base(directory, extension, continuousCapture) { }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified file path.
+        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified file pathname. An auto-incrementing number is added to each
+        /// new filename.
         /// </summary>
         /// <param name="fullPath">The absolute full path to save captured data to.</param>
-        public ImageStreamCaptureHandler(string fullPath)
-            : base(fullPath) { }
+        /// <param name="continuousCapture">When true, every frame is written to a file.</param>
+        public ImageStreamCaptureHandler(string fullPath, bool continuousCapture = true)
+            : base(fullPath, continuousCapture) { }
     }
 }

--- a/src/MMALSharp/Callbacks/FastImageOutputCallbackHandler.cs
+++ b/src/MMALSharp/Callbacks/FastImageOutputCallbackHandler.cs
@@ -32,9 +32,9 @@ namespace MMALSharp.Callbacks
             var eos = buffer.AssertProperty(MMALBufferProperties.MMAL_BUFFER_HEADER_FLAG_FRAME_END) ||
                       buffer.AssertProperty(MMALBufferProperties.MMAL_BUFFER_HEADER_FLAG_EOS);
 
-            if (eos && this.CaptureHandler is IFileStreamCaptureHandler)
+            if (eos)
             {
-                ((IFileStreamCaptureHandler)this.CaptureHandler).NewFile();
+                (this.CaptureHandler as IFileStreamCaptureHandler)?.NewFrame();
             }
         }
     }


### PR DESCRIPTION
This is sort of a cross-pollination of my previous effort and the existing capture handlers. As mentioned in the issue, it gives us the on-demand single-image capture capability I wanted, it retains the continuous-capture capability of the existing handler, and requires no extra classes or interfaces. It should also perform very marginally better, it shouldn't accidentally store incomplete frames, and the timestamp format is configurable when writing those types of filenames. 

`IFileStreamCaptureHandler`
* Adds the `NewFrame` method to be invoked when the callback reaches EOS

`FastImageOutputCallbackHandler`
* At EOS, invokes `NewFrame` instead of `NewFile`

`ImageStreamCaptureHandler`
* Adds optional `continuousCapture` argument to constructors to pass to the base

`FileStreamCaptureHandler`
* Derives from `MemoryStreamCaptureHandler`
* `CaptureNextFrame` bool property, resets after one write if `CaptureNextFrame` is false
* `ContinuousCapture` bool property, when true also keeps `CaptureNextFrame` true
* `FilenameDateTimeFormat` string property
* `LastWrittenPathname` string property
* `continuousCapture = true` argument to constructors to keep existing behavior
* Use last pathname for `GetFilename` and `GetFilepath`
* `NewFile` writes on demand and only when invoked by `NewFrame` (which is automatic)
* `NewFrame` manages the capture properties and resets the `MemoryStream`
* Private field `_skippingFirstPartialFrame` bool, true until `NewFrame` is invoked once

Conceptually, the only big change is that no "ambient" file stream is open, so it doesn't make sense to query for the "current" filename/path. Performance should be identical (or better) since file streams are just memory streams under the hood with some occasional flush behaviors. This also means `CurrentFilename` is only set when the filepath-based constructor is used.

Logically, `NewFrame` (invoked at EOS) checks if a capture is requested. If so, `NewFile` is invoked. If continuous capture is disabled, the capture flag is also disabled. Meanwhile, if `NewFile` is invoked externally, but next-frame capture is not enabled, the flag is set to true which waits for EOS, then `NewFrame` invokes `NewFile`.

Fixes #163 