### PR TITLE
Update timestamp annotations

### DIFF
--- a/src/MMALSharp.Processing/Handlers/IFileStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/IFileStreamCaptureHandler.cs
@@ -16,6 +16,11 @@ namespace MMALSharp.Handlers
         void NewFile();
 
         /// <summary>
+        /// The callback handler has received an end-of-stream marker.
+        /// </summary>
+        void NewFrame();
+
+        /// <summary>
         /// Gets the filepath that a FileStream points to.
         /// </summary>
         /// <returns>The filepath.</returns>

--- a/src/MMALSharp.Processing/Handlers/ImageStreamCaptureHandler.cs
+++ b/src/MMALSharp.Processing/Handlers/ImageStreamCaptureHandler.cs
@@ -13,18 +13,22 @@ namespace MMALSharp.Handlers
     public class ImageStreamCaptureHandler : FileStreamCaptureHandler
     {
         /// <summary>
-        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified directory and filename extension.
+        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified directory and filename extension. Filenames will be in the
+        /// format defined by the <see cref="FilenameDateTimeFormat"/> property.
         /// </summary>
         /// <param name="directory">The directory to save captured images.</param>
         /// <param name="extension">The filename extension for saving files.</param>
-        public ImageStreamCaptureHandler(string directory, string extension)
-            : base(directory, extension) { }
+        /// <param name="continuousCapture">When true, every frame is written to a file.</param>
+        public ImageStreamCaptureHandler(string directory, string extension, bool continuousCapture = true)
+            : base(directory, extension, continuousCapture) { }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified file path.
+        /// Creates a new instance of the <see cref="ImageStreamCaptureHandler"/> class with the specified file pathname. An auto-incrementing number is added to each
+        /// new filename.
         /// </summary>
         /// <param name="fullPath">The absolute full path to save captured data to.</param>
-        public ImageStreamCaptureHandler(string fullPath)
-            : base(fullPath) { }
+        /// <param name="continuousCapture">When true, every frame is written to a file.</param>
+        public ImageStreamCaptureHandler(string fullPath, bool continuousCapture = true)
+            : base(fullPath, continuousCapture) { }
     }
 }

--- a/src/MMALSharp/Callbacks/FastImageOutputCallbackHandler.cs
+++ b/src/MMALSharp/Callbacks/FastImageOutputCallbackHandler.cs
@@ -32,9 +32,9 @@ namespace MMALSharp.Callbacks
             var eos = buffer.AssertProperty(MMALBufferProperties.MMAL_BUFFER_HEADER_FLAG_FRAME_END) ||
                       buffer.AssertProperty(MMALBufferProperties.MMAL_BUFFER_HEADER_FLAG_EOS);
 
-            if (eos && this.CaptureHandler is IFileStreamCaptureHandler)
+            if (eos)
             {
-                ((IFileStreamCaptureHandler)this.CaptureHandler).NewFile();
+                (this.CaptureHandler as IFileStreamCaptureHandler)?.NewFrame();
             }
         }
     }

--- a/src/MMALSharp/Config/AnnotateImage.cs
+++ b/src/MMALSharp/Config/AnnotateImage.cs
@@ -29,6 +29,42 @@ namespace MMALSharp.Config
     }
 
     /// <summary>
+    /// Used to ensure the date/time annotations are updated for longer-running operations such as video recording or streaming.
+    /// </summary>
+    public enum DateTimeTextRefreshRate
+    {
+        /// <summary>
+        /// Do not automatically refresh the <see cref="AnnotateImage.ShowDateText"/> and <see cref="AnnotateImage.ShowTimeText"/> annotations.
+        /// These annotations can be explicitly refreshed by calling <see cref="MMALCamera.EnableAnnotation"/>.
+        /// </summary>
+        Disabled = 0,
+
+        /// <summary>
+        /// Typically used when the time is not displayed.
+        /// Update interval is once per minute.
+        /// </summary>
+        Daily = 60000,
+
+        /// <summary>
+        /// Typically used with the default "HH:mm" <see cref="AnnotateImage.TimeFormat"/>.
+        /// Update interval is once per second.
+        /// </summary>
+        Minutes = 1000,
+
+        /// <summary>
+        /// Useful if the <see cref="AnnotateImage.TimeFormat"/> is altered to display seconds, such as "HH:mm:ss".
+        /// Update interval is 250ms.
+        /// </summary>
+        Seconds = 250,
+
+        /// <summary>
+        /// Useful if the <see cref="AnnotateImage.TimeFormat"/> is altered to display fractional seconds, such as "HH:mm:ss.ffff".
+        /// Update interval is 41ms, which approximately equates to 24FPS.
+        /// </summary>
+        SubSecond = 41
+    }
+
+    /// <summary>
     /// The <see cref="AnnotateImage"/> type is for use with the image annotation functionality.
     /// This will produce a textual overlay on image stills depending on the options enabled.
     /// </summary>
@@ -99,6 +135,22 @@ namespace MMALSharp.Config
         /// Show the current time.
         /// </summary>
         public bool ShowTimeText { get; set; }
+
+        /// <summary>
+        /// The DateTime format string applied when <see cref="ShowDateText"/> is true. The default is "dd/MM/yyyy".
+        /// </summary>
+        public string DateFormat { get; set; } = "dd/MM/yyyy";
+
+        /// <summary>
+        /// The DateTime format string applied when <see cref="ShowTimeText"/> is true. The default is "HH:mm".
+        /// </summary>
+        public string TimeFormat { get; set; } = "HH:mm";
+
+        /// <summary>
+        /// The approximate frequency at which date and time annotations are refreshed. The default is 
+        /// <see cref="DateTimeTextRefreshRate.Minutes"/> which matches the resolution of the default <see cref="TimeFormat"/>.
+        /// </summary>
+        public DateTimeTextRefreshRate RefreshRate { get; set; } = DateTimeTextRefreshRate.Minutes;
         
         /// <summary>
         /// Justify annotation text.

--- a/src/MMALSharp/MMALCamera.cs
+++ b/src/MMALSharp/MMALCamera.cs
@@ -363,16 +363,35 @@ namespace MMALSharp
 
             this.Camera.SetShutterSpeed(MMALCameraConfig.ShutterSpeed);
 
+            // Prepare arguments for the annotation-refresh task
+            var ctsRefreshAnnotation = new CancellationTokenSource();
+            var refreshInterval = (int)(MMALCameraConfig.Annotate?.RefreshRate ?? 0);
+            if(!(MMALCameraConfig.Annotate?.ShowDateText ?? false) && !(MMALCameraConfig.Annotate?.ShowTimeText ?? false))
+            {
+                refreshInterval = 0;
+            }
+
             // We now begin capturing on the camera, processing will commence based on the pipeline configured.
             this.StartCapture(cameraPort);
             
             if (cancellationToken == CancellationToken.None)
             {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                await Task.WhenAny(
+                    Task.WhenAll(tasks),
+                    RefreshAnnotations(refreshInterval, ctsRefreshAnnotation.Token)
+                    ).ConfigureAwait(false);
+
+                ctsRefreshAnnotation.Cancel();
             }
             else
             {
-                await Task.WhenAny(Task.WhenAll(tasks), cancellationToken.AsTask()).ConfigureAwait(false);
+                await Task.WhenAny(
+                    Task.WhenAll(tasks),
+                    RefreshAnnotations(refreshInterval, ctsRefreshAnnotation.Token),
+                    cancellationToken.AsTask()
+                    ).ConfigureAwait(false);
+
+                ctsRefreshAnnotation.Cancel();
 
                 foreach (var component in handlerComponents)
                 {
@@ -502,6 +521,34 @@ namespace MMALSharp
             this.Camera.Dispose();
 
             BcmHost.bcm_host_deinit();
+        }
+
+        /// <summary>
+        /// Periodically invokes <see cref="MMALCameraComponentExtensions.SetAnnotateSettings(MMALCameraComponent)"/> to update date/time annotations.
+        /// </summary>
+        /// <param name="msInterval">Update frequency in milliseconds, or 0 to disable.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for a task to complete.</param>
+        /// <returns>The awaitable Task.</returns>
+        private async Task RefreshAnnotations(int msInterval, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if(msInterval == 0)
+                {
+                    await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    while(!cancellationToken.IsCancellationRequested)
+                    {
+                        await Task.Delay(msInterval, cancellationToken).ConfigureAwait(false);
+                        this.Camera.SetAnnotateSettings();
+                    }
+                }
+            }
+            catch(OperationCanceledException)
+            { // disregard token cancellation
+            }
         }
 
         /// <summary>

--- a/src/MMALSharp/MMALCameraExtensions.cs
+++ b/src/MMALSharp/MMALCameraExtensions.cs
@@ -246,12 +246,12 @@ namespace MMALSharp
 
                 if (MMALCameraConfig.Annotate.ShowTimeText)
                 {
-                    sb.Append(DateTime.Now.ToString("HH:mm") + " ");
+                    sb.Append(DateTime.Now.ToString(MMALCameraConfig.Annotate.TimeFormat) + " ");
                 }
 
                 if (MMALCameraConfig.Annotate.ShowDateText)
                 {
-                    sb.Append(DateTime.Now.ToString("dd/MM/yyyy") + " ");
+                    sb.Append(DateTime.Now.ToString(MMALCameraConfig.Annotate.DateFormat) + " ");
                 }
 
                 if (MMALCameraConfig.Annotate.ShowShutterSettings)


### PR DESCRIPTION
Hi Ian, as mentioned in that feature-request issue, these changes refresh date/time annotations at a configurable interval based on the time resolution of the annotation. The format strings are configurable.

`AnnotateImage`
* Adds string prop `DateFormat` which defaults to the formerly hard-coded "dd/MM/yyyy"
* Adds string prop `TimeFormat` which defaults to the formerly hard-coded "HH:mm"
* Adds property `RefreshRate` of the `DateTimeTextRefreshRate` type described below

`MMALCameraComponentExtensions`
* Altered to use the `DateFormat` and `TimeFormat` formatting strings

`MMALCamera`
* Modifies `ProcessAsync` to determine a refresh interval, invoke a refresh task, and control it by token
* Adds a private `RefreshAnnotation` method which awakens periodically to call `SetAnnotateSettings`

`DateTimeTextRefreshRate` intervals
* Disabled - consumer can invoke `EnableAnnotation` on some custom scheme
* Daily - once per minute, useful if time is not shown at all
* Minutes - once per second, useful for the default "HH:mm" format
* Seconds - once every 250ms, useful for an "HH:mm:ss" format
* SubSecond - every 41ms, which is about 24 FPS, useful for the "HH:mm:ss.ffff" format

On my Pi4 with the 5MP camera encoding a 1080p MP4 (fragmented), I was still able to get a steady 25FPS with the subsecond interval. I imagine older model Pis or maybe the 8MP camera could start to miss frames at 41ms, given I timed the annotation update at about 0.4-0.5ms per invocation. 

No conflicts with my other open PR. Hope you like it.